### PR TITLE
fix: add auth to unprotected endpoints, redact .env.example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -2,7 +2,7 @@ PORT=3001
 NODE_ENV=development
 
 # Supabase
-SUPABASE_URL=https://oamdvrxmzbnssgxnfvuq.supabase.co
+SUPABASE_URL=https://your-project-id.supabase.co
 SUPABASE_SERVICE_KEY=your_service_role_key
 
 # Hyperliquid

--- a/server/src/routes/leaderboard.routes.ts
+++ b/server/src/routes/leaderboard.routes.ts
@@ -47,8 +47,8 @@ leaderboardRoutes.post('/sync', authMiddleware, async (req: AuthenticatedRequest
   }
 });
 
-// Sync all users' leaderboard stats (admin function)
-leaderboardRoutes.post('/sync-all', async (req, res) => {
+// Sync all users' leaderboard stats (admin function, requires auth)
+leaderboardRoutes.post('/sync-all', authMiddleware, async (req, res) => {
   try {
     await leaderboardService.syncAllUsers();
     res.json({ success: true, message: 'All leaderboard stats synced' });

--- a/server/src/routes/stressTest.routes.ts
+++ b/server/src/routes/stressTest.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { validateBody } from '../middleware/validation.middleware.js';
+import { authMiddleware } from '../middleware/auth.middleware.js';
 import { logger } from '../lib/logger.js';
 import type { StressTestService } from '../services/stress-test/index.js';
 
@@ -17,7 +18,7 @@ const speedSchema = z.object({
   speed: z.enum(['off', 'slow', 'medium', 'fast']),
 });
 
-stressTestRoutes.post('/speed', validateBody(speedSchema), async (req, res) => {
+stressTestRoutes.post('/speed', authMiddleware, validateBody(speedSchema), async (req, res) => {
   try {
     const { speed } = req.body;
 


### PR DESCRIPTION
## Summary
- Add `authMiddleware` to stress-test POST `/speed` (was unauthenticated, anyone could toggle stress test on prod)
- Add `authMiddleware` to leaderboard POST `/sync-all` (was unauthenticated, DoS vector)
- Replace real Supabase project URL in `server/.env.example` with placeholder

From /cso security audit findings H1, H2, H3.

## Test plan
- [x] Server lint passes
- [x] Server typecheck passes
- [x] 69/69 tests passing
- [ ] CI pipeline passes