### PR TITLE
feat: bridge loop, realistic execution, event sourcing, 118 tests

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,87 @@
+# Design System
+
+## Color Tokens
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Background | `#0d0f11` | Page background, card backgrounds |
+| Surface | `#1a1d21` | Hover states, input backgrounds, elevated surfaces |
+| Border | `#1e2126` | Card borders, dividers, separators |
+| Green | `#3dd9a4` | Long positions, profit, positive PnL, connection status |
+| Red | `#f6465d` | Short positions, loss, negative PnL, liquidation, close actions |
+| Cyan | `#00d4ff` | Primary accent, selected tabs, active states, links |
+| White | `#ffffff` | Primary text, headings, asset names |
+| Gray 400 | `text-gray-400` | Secondary text, labels, inactive icons |
+| Gray 500 | `text-gray-500` | Tertiary text, column headers, metadata |
+| Gray 600 | `text-gray-600` | Disabled text, divider text |
+
+## Typography
+
+- **UI text:** System font stack (default Tailwind sans)
+- **Numbers:** Monospace (`font-mono`) for all prices, sizes, PnL, percentages
+- **Data-dense components:** 9-11px (`text-[9px]` to `text-[11px]`)
+- **Headers/labels:** 12-14px (`text-xs` to `text-sm`)
+- **Primary values:** 16-20px (`text-base` to `text-xl`) for current price, account balance
+- **Tabular numbers:** Use `tabular-nums` for animated/streaming values to prevent layout shift
+
+## Spacing
+
+- **Card padding:** `px-3 py-2` (compact) or `px-4 py-3` (standard)
+- **Gap between cards:** `gap-2` (8px)
+- **Page padding:** `p-2` (desktop), `px-3 py-2.5` (mobile header)
+- **Inner grid gaps:** `gap-2` for data grids, `gap-3` for nav items
+
+## Component Patterns
+
+### Cards
+- Dark background (`bg-[#0d0f11]`), thin border (`border border-[#1e2126]`), rounded (`rounded-lg`)
+- No shadows. Borders create hierarchy.
+
+### Expandable Rows
+- Click to expand/collapse with chevron rotation
+- Expanded content uses nested grids for data display
+- `border-b border-[#1e2126]/50` between rows (50% opacity for subtlety)
+
+### Animated Numbers
+- `<AnimatedNumber>` component for live PnL, prices
+- 200ms transition duration
+- Green/red color based on positive/negative value
+
+### Buttons
+- **Primary action:** Solid background with accent color
+- **Destructive:** Text-only in red (`text-[#f6465d]`), no background
+- **Disabled:** `cursor-not-allowed`, reduced opacity or gray text
+- **Touch targets:** `touch-manipulation` class on all interactive elements
+
+### Status Indicators
+- Connection: 2px dot (`w-2 h-2 rounded-full`), green=connected, red=disconnected
+- Signal activity: Pulsing green dot (`animate-pulse`)
+
+### Tabs
+- Active: white text + cyan bottom border (`border-b-2 border-[#00d4ff]`)
+- Inactive: gray text, no border
+
+### Badges
+- Small inline tags: `text-[9px] px-1 py-0.5 rounded font-medium`
+- Color-coded: green bg for long, red bg for short, with 10% opacity backgrounds
+- Source badge: `SIG` tag in cyan (`text-[#00d4ff] bg-[#00d4ff]/10`) for signal-sourced positions
+
+## Layout
+
+### Desktop (md+)
+- Three-column: left sidebar (orderbook + trades, 256px), center (chart + positions, flex), right sidebar (account + signals + order form, 320px)
+- `gap-2` between columns
+- Full height, no scroll on page level
+
+### Mobile
+- Two-tab navigation: Markets (chart or orderbook) | Trade (orderbook + order form split)
+- Bottom nav bar with `pb-12` for safe area
+- `100dvh` for full viewport height
+
+## Interaction States
+
+- **Hover:** `hover:bg-[#1a1d21]` on interactive rows
+- **Active/pressed:** `active:bg-[#1a1d21]` on mobile touch targets
+- **Loading:** `animate-pulse` on skeleton text, `opacity-50` on loading elements
+- **Error:** Toast notifications via ToastContext (top-right, auto-dismiss)
+- **Empty:** Centered gray text with optional action link (e.g., "Login to trade")

--- a/client/src/components/trading/SuggestedTrades.tsx
+++ b/client/src/components/trading/SuggestedTrades.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState, useCallback } from 'react';
 import { cn, formatPrice } from '../../lib/utils';
+import { Modal } from '../ui/Modal';
+import { usePositionsStore } from '../../hooks/usePositions';
+import { useAuthStore } from '../../hooks/useAuth';
+import { useAccountStore } from '../../hooks/useAccount';
+import { useAssetsStore } from '../../hooks/useAssets';
+import { useToast } from '../../context/ToastContext';
 
 interface SuggestedTrade {
   id: string;
@@ -45,6 +51,13 @@ export function SuggestedTrades({ onTradeSelect, selectedAsset, compact }: Sugge
   const [data, setData] = useState<SuggestionsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [confirmTrade, setConfirmTrade] = useState<SuggestedTrade | null>(null);
+  const [isExecuting, setIsExecuting] = useState(false);
+
+  const { placeOrder } = usePositionsStore();
+  const { isAuthenticated } = useAuthStore();
+  const { account, fetchAccount } = useAccountStore();
+  const { addToast } = useToast();
 
   const fetchSuggestions = useCallback(async () => {
     try {
@@ -62,9 +75,58 @@ export function SuggestedTrades({ onTradeSelect, selectedAsset, compact }: Sugge
 
   useEffect(() => {
     fetchSuggestions();
-    const interval = setInterval(fetchSuggestions, 30_000); // Refresh every 30s
+    const interval = setInterval(fetchSuggestions, 30_000);
     return () => clearInterval(interval);
   }, [fetchSuggestions]);
+
+  const handleTakeTrade = useCallback((trade: SuggestedTrade) => {
+    if (!isAuthenticated) {
+      addToast({ type: 'error', title: 'Login Required', message: 'Please login to take trades' });
+      return;
+    }
+    setConfirmTrade(trade);
+  }, [isAuthenticated, addToast]);
+
+  const handleConfirmExecution = useCallback(async () => {
+    if (!confirmTrade) return;
+
+    setIsExecuting(true);
+    try {
+      // Notional-based sizing: $500 default exposure regardless of coin price
+      const DEFAULT_NOTIONAL = 500;
+      const price = confirmTrade.currentPrice || confirmTrade.entryPrice || 1;
+      const baseSize = DEFAULT_NOTIONAL / price;
+      const size = confirmTrade.kellyFraction
+        ? Math.max(baseSize * 0.1, confirmTrade.kellyFraction * baseSize)
+        : baseSize;
+
+      await placeOrder({
+        asset: confirmTrade.coin,
+        side: confirmTrade.direction,
+        size,
+        leverage: 10,
+        source: 'signal',
+        signalId: confirmTrade.id,
+      });
+
+      addToast({
+        type: 'success',
+        title: 'Trade Executed',
+        message: `${confirmTrade.direction.toUpperCase()} ${confirmTrade.coin} from signal`,
+      });
+
+      fetchAccount();
+      setConfirmTrade(null);
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: 'Trade Failed',
+        message: err instanceof Error ? err.message : 'Failed to execute trade',
+      });
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [confirmTrade, placeOrder, addToast, fetchAccount]);
 
   if (isLoading) {
     return (
@@ -91,7 +153,6 @@ export function SuggestedTrades({ onTradeSelect, selectedAsset, compact }: Sugge
   const suggestions = data.suggestions;
   const stats = data.stats;
 
-  // Filter to selected asset if provided, but always show all if empty
   const filtered = selectedAsset
     ? suggestions.filter(s => s.coin === selectedAsset)
     : suggestions;
@@ -99,71 +160,96 @@ export function SuggestedTrades({ onTradeSelect, selectedAsset, compact }: Sugge
   const displayed = compact ? filtered.slice(0, 3) : filtered.slice(0, 10);
 
   return (
-    <div className="bg-[#0d0f11] rounded-lg border border-[#1e2126]">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-[#1e2126]">
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-[#3dd9a4] animate-pulse" />
-          <span className="text-xs font-medium text-white">Tracker Signals</span>
-          {stats && (
-            <span className="text-[10px] text-gray-500">
-              {stats.trackedTraders} traders
+    <>
+      <div className="bg-[#0d0f11] rounded-lg border border-[#1e2126]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-2 border-b border-[#1e2126]">
+          <div className="flex items-center gap-2">
+            <div className="w-2 h-2 rounded-full bg-[#3dd9a4] animate-pulse" />
+            <span className="text-xs font-medium text-white">Tracker Signals</span>
+            {stats && (
+              <span className="text-[10px] text-gray-500">
+                {stats.trackedTraders} traders
+              </span>
+            )}
+          </div>
+          {stats?.signalWinRate !== null && stats?.signalWinRate !== undefined && (
+            <span className="text-[10px] text-[#3dd9a4] font-mono">
+              {(stats.signalWinRate * 100).toFixed(0)}% WR
             </span>
           )}
         </div>
-        {stats?.signalWinRate !== null && stats?.signalWinRate !== undefined && (
-          <span className="text-[10px] text-[#3dd9a4] font-mono">
-            {(stats.signalWinRate * 100).toFixed(0)}% WR
-          </span>
+
+        {/* Suggestions list */}
+        {displayed.length === 0 ? (
+          <div className="px-3 py-4 text-center">
+            <p className="text-[10px] text-gray-500">
+              {selectedAsset
+                ? `No active signals for ${selectedAsset}`
+                : 'No active signals right now'}
+            </p>
+            {suggestions.length > 0 && selectedAsset && (
+              <p className="text-[10px] text-gray-600 mt-1">
+                {suggestions.length} signal{suggestions.length !== 1 ? 's' : ''} on other coins
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="divide-y divide-[#1e2126]/50">
+            {displayed.map(trade => (
+              <SuggestionRow
+                key={trade.id}
+                trade={trade}
+                onSelect={onTradeSelect}
+                onTakeTrade={handleTakeTrade}
+                isAuthenticated={isAuthenticated}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Show more indicator */}
+        {filtered.length > displayed.length && (
+          <div className="px-3 py-1.5 text-center border-t border-[#1e2126]/50">
+            <span className="text-[10px] text-gray-500">
+              +{filtered.length - displayed.length} more
+            </span>
+          </div>
         )}
       </div>
 
-      {/* Suggestions list */}
-      {displayed.length === 0 ? (
-        <div className="px-3 py-4 text-center">
-          <p className="text-[10px] text-gray-500">
-            {selectedAsset
-              ? `No active signals for ${selectedAsset}`
-              : 'No active signals right now'}
-          </p>
-          {suggestions.length > 0 && selectedAsset && (
-            <p className="text-[10px] text-gray-600 mt-1">
-              {suggestions.length} signal{suggestions.length !== 1 ? 's' : ''} on other coins
-            </p>
-          )}
-        </div>
-      ) : (
-        <div className="divide-y divide-[#1e2126]/50">
-          {displayed.map(trade => (
-            <SuggestionRow
-              key={trade.id}
-              trade={trade}
-              onSelect={onTradeSelect}
-            />
-          ))}
-        </div>
+      {/* Trade Confirmation Modal */}
+      {confirmTrade && (
+        <TradeConfirmModal
+          trade={confirmTrade}
+          isOpen={!!confirmTrade}
+          isExecuting={isExecuting}
+          onConfirm={handleConfirmExecution}
+          onClose={() => setConfirmTrade(null)}
+          availableBalance={account?.availableMargin || 0}
+        />
       )}
-
-      {/* Show more indicator */}
-      {filtered.length > displayed.length && (
-        <div className="px-3 py-1.5 text-center border-t border-[#1e2126]/50">
-          <span className="text-[10px] text-gray-500">
-            +{filtered.length - displayed.length} more
-          </span>
-        </div>
-      )}
-    </div>
+    </>
   );
 }
 
-function SuggestionRow({ trade, onSelect }: { trade: SuggestedTrade; onSelect?: (t: SuggestedTrade) => void }) {
+function SuggestionRow({
+  trade,
+  onSelect,
+  onTakeTrade,
+  isAuthenticated,
+}: {
+  trade: SuggestedTrade;
+  onSelect?: (t: SuggestedTrade) => void;
+  onTakeTrade: (t: SuggestedTrade) => void;
+  isAuthenticated: boolean;
+}) {
   const isLong = trade.direction === 'long';
   const pnlPct = trade.entryPrice > 0
     ? ((trade.currentPrice - trade.entryPrice) / trade.entryPrice * 100) * (isLong ? 1 : -1)
     : 0;
   const isProfitable = pnlPct >= 0;
 
-  // Confidence badge color
   const confColor = trade.confidence >= 70
     ? 'text-[#3dd9a4] bg-[#3dd9a4]/10'
     : trade.confidence >= 50
@@ -174,50 +260,203 @@ function SuggestionRow({ trade, onSelect }: { trade: SuggestedTrade; onSelect?: 
     ? `${trade.traderCount} trader${trade.traderCount !== 1 ? 's' : ''}`
     : trade.traderTier || 'tracker';
 
+  const { getAsset } = useAssetsStore();
+  const assetAvailable = !!getAsset(trade.coin);
+
   return (
-    <button
-      onClick={() => onSelect?.(trade)}
-      className="w-full px-3 py-2 hover:bg-[#1a1d21] transition-colors text-left"
-    >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          {/* Coin + direction */}
-          <span className={cn(
-            'text-[11px] font-medium',
-            isLong ? 'text-[#3dd9a4]' : 'text-[#f6465d]'
-          )}>
-            {trade.coin}
-          </span>
-          <span className={cn(
-            'text-[9px] px-1 py-0.5 rounded font-medium',
-            isLong ? 'text-[#3dd9a4] bg-[#3dd9a4]/10' : 'text-[#f6465d] bg-[#f6465d]/10'
-          )}>
-            {trade.direction.toUpperCase()}
-          </span>
-        </div>
-
-        {/* Confidence badge */}
-        <span className={cn('text-[10px] px-1.5 py-0.5 rounded font-mono', confColor)}>
-          {trade.confidence}
-        </span>
-      </div>
-
-      <div className="flex items-center justify-between mt-1">
-        <span className="text-[9px] text-gray-500">{typeLabel}</span>
-        <div className="flex items-center gap-2">
-          <span className="text-[9px] text-gray-500 font-mono">
-            {formatPrice(trade.entryPrice)}
-          </span>
-          {trade.entryPrice > 0 && (
+    <div className="flex items-center px-3 py-2 hover:bg-[#1a1d21] transition-colors">
+      <button
+        onClick={() => onSelect?.(trade)}
+        className="flex-1 text-left touch-manipulation"
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
             <span className={cn(
-              'text-[9px] font-mono',
-              isProfitable ? 'text-[#3dd9a4]' : 'text-[#f6465d]'
+              'text-[11px] font-medium',
+              isLong ? 'text-[#3dd9a4]' : 'text-[#f6465d]'
             )}>
-              {isProfitable ? '+' : ''}{pnlPct.toFixed(1)}%
+              {trade.coin}
             </span>
+            <span className={cn(
+              'text-[9px] px-1 py-0.5 rounded font-medium',
+              isLong ? 'text-[#3dd9a4] bg-[#3dd9a4]/10' : 'text-[#f6465d] bg-[#f6465d]/10'
+            )}>
+              {trade.direction.toUpperCase()}
+            </span>
+          </div>
+
+          <span className={cn('text-[10px] px-1.5 py-0.5 rounded font-mono', confColor)}>
+            {trade.confidence}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between mt-1">
+          <span className="text-[9px] text-gray-500">{typeLabel}</span>
+          <div className="flex items-center gap-2">
+            <span className="text-[9px] text-gray-500 font-mono">
+              {formatPrice(trade.entryPrice)}
+            </span>
+            {trade.entryPrice > 0 && (
+              <span className={cn(
+                'text-[9px] font-mono',
+                isProfitable ? 'text-[#3dd9a4]' : 'text-[#f6465d]'
+              )}>
+                {isProfitable ? '+' : ''}{pnlPct.toFixed(1)}%
+              </span>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {/* Take Trade button */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onTakeTrade(trade);
+        }}
+        disabled={!isAuthenticated || !assetAvailable}
+        title={
+          !isAuthenticated
+            ? 'Login to trade'
+            : !assetAvailable
+            ? 'Asset not available in sim'
+            : `Take ${trade.direction} ${trade.coin}`
+        }
+        className={cn(
+          'ml-2 px-2 py-1 rounded text-[9px] font-medium transition-colors touch-manipulation shrink-0',
+          isAuthenticated && assetAvailable
+            ? 'text-[#00d4ff] bg-[#00d4ff]/10 hover:bg-[#00d4ff]/20'
+            : 'text-gray-600 bg-gray-600/10 cursor-not-allowed'
+        )}
+      >
+        Take
+      </button>
+    </div>
+  );
+}
+
+function TradeConfirmModal({
+  trade,
+  isOpen,
+  isExecuting,
+  onConfirm,
+  onClose,
+  availableBalance,
+}: {
+  trade: SuggestedTrade;
+  isOpen: boolean;
+  isExecuting: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+  availableBalance: number;
+}) {
+  const isLong = trade.direction === 'long';
+  const DEFAULT_NOTIONAL = 500;
+  const price = trade.currentPrice || trade.entryPrice || 1;
+  const baseSize = DEFAULT_NOTIONAL / price;
+  const size = trade.kellyFraction
+    ? Math.max(baseSize * 0.1, trade.kellyFraction * baseSize)
+    : baseSize;
+  const leverage = 10;
+  const notional = size * price;
+  const marginRequired = notional / leverage;
+  const hasEnoughMargin = availableBalance >= marginRequired;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Confirm Signal Trade">
+      <div className="space-y-3">
+        {/* Signal source badge */}
+        <div className="flex items-center gap-2">
+          <span className="text-[9px] px-1.5 py-0.5 rounded font-medium text-[#00d4ff] bg-[#00d4ff]/10">
+            SIG
+          </span>
+          <span className="text-xs text-gray-400">Signal-sourced trade</span>
+        </div>
+
+        {/* Trade details grid */}
+        <div className="bg-[#0d0f11] rounded-lg border border-[#1e2126] p-3 space-y-2">
+          <div className="flex justify-between">
+            <span className="text-[11px] text-gray-400">Asset</span>
+            <span className="text-[11px] text-white font-medium">{trade.coin}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-[11px] text-gray-400">Direction</span>
+            <span className={cn(
+              'text-[11px] font-medium',
+              isLong ? 'text-[#3dd9a4]' : 'text-[#f6465d]'
+            )}>
+              {trade.direction.toUpperCase()}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-[11px] text-gray-400">Size</span>
+            <span className="text-[11px] text-white font-mono">{size.toFixed(4)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-[11px] text-gray-400">Entry Price</span>
+            <span className="text-[11px] text-white font-mono">{formatPrice(trade.currentPrice)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-[11px] text-gray-400">Leverage</span>
+            <span className="text-[11px] text-white font-mono">{leverage}x</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-[11px] text-gray-400">Margin Required</span>
+            <span className={cn(
+              'text-[11px] font-mono',
+              hasEnoughMargin ? 'text-white' : 'text-[#f6465d]'
+            )}>
+              ${marginRequired.toFixed(2)}
+            </span>
+          </div>
+          {trade.stopLoss && (
+            <div className="flex justify-between">
+              <span className="text-[11px] text-gray-400">Stop Loss</span>
+              <span className="text-[11px] text-[#f6465d] font-mono">{formatPrice(trade.stopLoss)}</span>
+            </div>
           )}
+          {trade.takeProfit1 && (
+            <div className="flex justify-between">
+              <span className="text-[11px] text-gray-400">Take Profit</span>
+              <span className="text-[11px] text-[#3dd9a4] font-mono">{formatPrice(trade.takeProfit1)}</span>
+            </div>
+          )}
+          <div className="flex justify-between">
+            <span className="text-[11px] text-gray-400">Confidence</span>
+            <span className="text-[11px] text-white font-mono">{trade.confidence}%</span>
+          </div>
+        </div>
+
+        {!hasEnoughMargin && (
+          <p className="text-[10px] text-[#f6465d]">
+            Insufficient margin. Available: ${availableBalance.toFixed(2)}
+          </p>
+        )}
+
+        {/* Action buttons */}
+        <div className="flex gap-2 pt-1">
+          <button
+            onClick={onClose}
+            className="flex-1 px-3 py-2 rounded-lg text-xs text-gray-400 hover:text-white hover:bg-[#1a1d21] transition-colors touch-manipulation"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isExecuting || !hasEnoughMargin}
+            className={cn(
+              'flex-1 px-3 py-2 rounded-lg text-xs font-medium transition-colors touch-manipulation',
+              isExecuting || !hasEnoughMargin
+                ? 'bg-gray-600/20 text-gray-500 cursor-not-allowed'
+                : isLong
+                ? 'bg-[#3dd9a4]/20 text-[#3dd9a4] hover:bg-[#3dd9a4]/30'
+                : 'bg-[#f6465d]/20 text-[#f6465d] hover:bg-[#f6465d]/30'
+            )}
+          >
+            {isExecuting ? 'Executing...' : `${trade.direction.toUpperCase()} ${trade.coin}`}
+          </button>
         </div>
       </div>
-    </button>
+    </Modal>
   );
 }

--- a/client/src/pages/TradingPage.tsx
+++ b/client/src/pages/TradingPage.tsx
@@ -222,6 +222,11 @@ export function TradingPage() {
                 )}>
                   {position.leverage}x
                 </span>
+                {position.source === 'signal' && (
+                  <span className="text-[8px] px-1 py-0.5 rounded font-medium text-[#00d4ff] bg-[#00d4ff]/10 leading-none">
+                    SIG
+                  </span>
+                )}
               </div>
             </div>
             

--- a/client/src/types/trading.ts
+++ b/client/src/types/trading.ts
@@ -3,6 +3,8 @@ export type OrderType = 'market' | 'limit';
 export type PositionStatus = 'open' | 'closed' | 'liquidated';
 export type LimitOrderStatus = 'pending' | 'filled' | 'cancelled' | 'expired';
 
+export type PositionSource = 'manual' | 'signal';
+
 export interface Position {
   id: string;
   userId: string;
@@ -18,6 +20,8 @@ export interface Position {
   unrealizedPnlPercent: number;
   realizedPnl: number;
   status: PositionStatus;
+  source: PositionSource;
+  signalId?: string;
   openedAt: string;
   closedAt?: string;
 }
@@ -103,6 +107,8 @@ export interface PlaceOrderRequest {
   leverage: number;
   type?: OrderType;
   price?: number; // Required for limit orders
+  source?: PositionSource;
+  signalId?: string;
 }
 
 export interface ClosePositionRequest {

--- a/server/src/__tests__/eventService.test.ts
+++ b/server/src/__tests__/eventService.test.ts
@@ -1,0 +1,114 @@
+import { EventService } from '../services/events/index';
+
+// Mock supabase
+let mockInsertResult: { error: any } = { error: null };
+let mockQueryResult: { data: any; error: any } = { data: [], error: null };
+
+function makeChain() {
+  const chain: any = {};
+  const returnSelf = () => chain;
+  chain.insert = jest.fn(() => Promise.resolve(mockInsertResult));
+  chain.select = jest.fn(returnSelf);
+  chain.eq = jest.fn(returnSelf);
+  chain.gte = jest.fn(returnSelf);
+  chain.lte = jest.fn(returnSelf);
+  chain.limit = jest.fn(returnSelf);
+  chain.order = jest.fn(returnSelf);
+  // Make chain thenable so `await query` resolves to mockQueryResult
+  chain.then = jest.fn((resolve: any) => resolve(mockQueryResult));
+  return chain;
+}
+
+const mockFrom = jest.fn(() => makeChain());
+
+jest.mock('../lib/supabase', () => ({
+  getSupabase: () => ({
+    from: mockFrom,
+  }),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+describe('EventService', () => {
+  let service: EventService;
+
+  beforeEach(() => {
+    service = new EventService();
+    jest.clearAllMocks();
+    mockInsertResult = { error: null };
+    mockQueryResult = { data: [], error: null };
+  });
+
+  describe('emit', () => {
+    it('inserts event into database', async () => {
+      await service.emit('trade_executed', { positionId: 'pos-1', asset: 'BTC' }, 'user-1');
+
+      expect(mockFrom).toHaveBeenCalledWith('events');
+    });
+
+    it('handles database errors gracefully', async () => {
+      mockInsertResult = { error: { message: 'DB connection failed' } };
+
+      // Should not throw
+      await service.emit('trade_executed', { positionId: 'pos-1' }, 'user-1');
+    });
+
+    it('handles exceptions gracefully', async () => {
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error('Unexpected crash');
+      });
+
+      // Should not throw
+      await service.emit('trade_executed', { positionId: 'pos-1' });
+    });
+  });
+
+  describe('getEvents', () => {
+    it('returns mapped events for user', async () => {
+      mockQueryResult = {
+        data: [
+          {
+            id: 'evt-1',
+            type: 'trade_executed',
+            payload: { asset: 'BTC' },
+            user_id: 'user-1',
+            session_id: null,
+            created_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+        error: null,
+      };
+
+      const events = await service.getEvents('user-1');
+
+      expect(events).toHaveLength(1);
+      expect(events[0].id).toBe('evt-1');
+      expect(events[0].type).toBe('trade_executed');
+      expect(events[0].payload).toEqual({ asset: 'BTC' });
+      expect(events[0].userId).toBe('user-1');
+    });
+
+    it('applies time range and type filters', async () => {
+      mockQueryResult = { data: [], error: null };
+
+      await service.getEvents('user-1', {
+        from: '2025-01-01',
+        to: '2025-01-31',
+        type: 'position_closed',
+        limit: 10,
+      });
+
+      // Verify the chain was called (filters applied)
+      expect(mockFrom).toHaveBeenCalledWith('events');
+    });
+
+    it('returns empty array on database error', async () => {
+      mockQueryResult = { data: null, error: { message: 'Query failed' } };
+
+      const events = await service.getEvents('user-1');
+      expect(events).toEqual([]);
+    });
+  });
+});

--- a/server/src/__tests__/middleware.test.ts
+++ b/server/src/__tests__/middleware.test.ts
@@ -1,0 +1,166 @@
+import { Request, Response, NextFunction } from 'express';
+import { authMiddleware, optionalAuthMiddleware, AuthenticatedRequest } from '../middleware/auth.middleware';
+import { rateLimitMiddleware } from '../middleware/rateLimit.middleware';
+
+// Mock supabase
+const mockGetUser = jest.fn();
+jest.mock('../lib/supabase', () => ({
+  getSupabase: () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+function mockReq(overrides: Partial<Request> = {}): AuthenticatedRequest {
+  return {
+    headers: {},
+    ip: '127.0.0.1',
+    socket: { remoteAddress: '127.0.0.1' },
+    ...overrides,
+  } as AuthenticatedRequest;
+}
+
+function mockRes(): Response {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+describe('authMiddleware', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('rejects requests without authorization header', async () => {
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await authMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing authorization token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with non-Bearer token', async () => {
+    const req = mockReq({ headers: { authorization: 'Basic abc123' } });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await authMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid tokens', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'invalid' } });
+
+    const req = mockReq({ headers: { authorization: 'Bearer invalid-token' } });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await authMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('sets userId and user on valid token', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-123', email: 'test@test.com' } },
+      error: null,
+    });
+
+    const req = mockReq({ headers: { authorization: 'Bearer valid-token' } });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await authMiddleware(req, res, next);
+
+    expect(req.userId).toBe('user-123');
+    expect(req.user).toEqual({ id: 'user-123', email: 'test@test.com' });
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('optionalAuthMiddleware', () => {
+  it('passes through without auth header', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    optionalAuthMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('delegates to authMiddleware when Bearer token present', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-456', email: 'a@b.com' } },
+      error: null,
+    });
+
+    const req = mockReq({ headers: { authorization: 'Bearer some-token' } });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await optionalAuthMiddleware(req, res, next);
+
+    // Should have delegated to authMiddleware which calls next
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('rateLimitMiddleware', () => {
+  it('allows requests under the limit', () => {
+    const req = mockReq({ ip: '10.0.0.1' });
+    const res = mockRes();
+    const next = jest.fn();
+
+    rateLimitMiddleware(req as Request, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', 100);
+  });
+
+  it('sets rate limit headers', () => {
+    const req = mockReq({ ip: '10.0.0.2' });
+    const res = mockRes();
+    const next = jest.fn();
+
+    rateLimitMiddleware(req as Request, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', 100);
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', expect.any(Number));
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', expect.any(Number));
+  });
+
+  it('blocks requests over the limit', () => {
+    const ip = '10.0.0.99';
+
+    // Exhaust the limit
+    for (let i = 0; i < 101; i++) {
+      const req = mockReq({ ip });
+      const res = mockRes();
+      const next = jest.fn();
+      rateLimitMiddleware(req as Request, res, next);
+
+      if (i < 100) {
+        expect(next).toHaveBeenCalled();
+      } else {
+        expect(res.status).toHaveBeenCalledWith(429);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+          error: 'Too many requests',
+        }));
+        expect(next).not.toHaveBeenCalled();
+      }
+    }
+  });
+});

--- a/server/src/__tests__/orderExecutor.test.ts
+++ b/server/src/__tests__/orderExecutor.test.ts
@@ -130,23 +130,29 @@ describe('OrderExecutor', () => {
       });
     });
 
-    it('calls RPC with correct parameters for a long order', async () => {
+    it('calls RPC with slipped price for a long order', async () => {
+      // Notional = 0.1 * 50000 = 5000
+      // Slippage = (5000/10000) * 5 bps = 2.5 bps = 0.00025
+      // Slipped price (long) = 50000 * 1.00025 = 50012.5
+      // Margin = (0.1 * 50012.5) / 10 = 500.125
       const mockPosition = {
         id: 'pos-1',
         user_id: 'user-1',
         asset: 'BTC',
         side: 'long',
-        entry_price: 50000,
-        current_price: 50000,
+        entry_price: 50012.5,
+        current_price: 50012.5,
         size: 0.1,
         leverage: 10,
-        margin: 500,
+        margin: 500.125,
         liquidation_price: 45250,
         unrealized_pnl: 0,
         unrealized_pnl_percent: 0,
         realized_pnl: 0,
         status: 'open',
         opened_at: '2025-01-01T00:00:00Z',
+        source: 'manual',
+        signal_id: null,
       };
 
       mockRpc.mockResolvedValue({ data: mockPosition, error: null });
@@ -158,29 +164,35 @@ describe('OrderExecutor', () => {
         leverage: 10,
       }, 50000);
 
-      expect(mockRpc).toHaveBeenCalledWith('execute_market_order', expect.objectContaining({
-        p_user_id: 'user-1',
-        p_asset: 'BTC',
-        p_side: 'long',
-        p_size: 0.1,
-        p_leverage: 10,
-        p_entry_price: 50000,
-        p_margin: 500, // 0.1 * 50000 / 10
-      }));
+      const rpcCall = mockRpc.mock.calls[0];
+      expect(rpcCall[0]).toBe('execute_market_order');
+      expect(rpcCall[1].p_user_id).toBe('user-1');
+      expect(rpcCall[1].p_asset).toBe('BTC');
+      expect(rpcCall[1].p_side).toBe('long');
+      expect(rpcCall[1].p_size).toBe(0.1);
+      expect(rpcCall[1].p_leverage).toBe(10);
+      // Entry price includes slippage (long slips up)
+      expect(rpcCall[1].p_entry_price).toBeCloseTo(50012.5, 1);
+      // Margin based on slipped notional
+      expect(rpcCall[1].p_margin).toBeCloseTo(500.125, 1);
 
       expect(result.side).toBe('long');
       expect(result.asset).toBe('BTC');
       expect(result.status).toBe('open');
     });
 
-    it('correctly calculates margin for the RPC call', async () => {
+    it('applies slippage in opposite direction for short orders', async () => {
+      // Notional = 5 * 3000 = 15000
+      // Slippage = (15000/10000) * 5 bps = 7.5 bps = 0.00075
+      // Slipped price (short) = 3000 * (1 - 0.00075) = 2997.75
+      // Margin = (5 * 2997.75) / 20 = 749.4375
       mockRpc.mockResolvedValue({
         data: {
           id: 'pos-1', user_id: 'user-1', asset: 'ETH', side: 'short',
-          entry_price: 3000, current_price: 3000, size: 5, leverage: 20,
-          margin: 750, liquidation_price: 3142.5, unrealized_pnl: 0,
+          entry_price: 2997.75, current_price: 2997.75, size: 5, leverage: 20,
+          margin: 749.4375, liquidation_price: 3142.5, unrealized_pnl: 0,
           unrealized_pnl_percent: 0, realized_pnl: 0, status: 'open',
-          opened_at: '2025-01-01T00:00:00Z',
+          opened_at: '2025-01-01T00:00:00Z', source: 'manual', signal_id: null,
         },
         error: null,
       });
@@ -192,10 +204,10 @@ describe('OrderExecutor', () => {
         leverage: 20,
       }, 3000);
 
-      // Margin = (5 * 3000) / 20 = 750
-      expect(mockRpc).toHaveBeenCalledWith('execute_market_order',
-        expect.objectContaining({ p_margin: 750 })
-      );
+      const rpcCall = mockRpc.mock.calls[0];
+      // Short slips down (worse entry for shorts)
+      expect(rpcCall[1].p_entry_price).toBeCloseTo(2997.75, 1);
+      expect(rpcCall[1].p_margin).toBeCloseTo(749.4375, 1);
     });
 
     it('maps insufficient funds error from RPC', async () => {
@@ -231,8 +243,80 @@ describe('OrderExecutor', () => {
     });
   });
 
+  describe('executeMarketOrder - source attribution', () => {
+    beforeEach(() => {
+      mockSingle.mockResolvedValue({
+        data: {
+          id: 'account-1',
+          user_id: 'user-1',
+          balance: 100000,
+          initial_balance: 100000,
+          reset_count: 0,
+        },
+        error: null,
+      });
+    });
+
+    it('passes source=signal and signalId to RPC when provided', async () => {
+      const mockPosition = {
+        id: 'pos-1', user_id: 'user-1', asset: 'BTC', side: 'long',
+        entry_price: 50012.5, current_price: 50012.5, size: 0.1, leverage: 10,
+        margin: 500.125, liquidation_price: 45250, unrealized_pnl: 0,
+        unrealized_pnl_percent: 0, realized_pnl: 0, status: 'open',
+        opened_at: '2025-01-01T00:00:00Z', source: 'signal',
+        signal_id: 'sig-abc-123',
+      };
+
+      mockRpc.mockResolvedValue({ data: mockPosition, error: null });
+
+      const result = await executor.executeMarketOrder('user-1', {
+        asset: 'BTC',
+        side: 'long',
+        size: 0.1,
+        leverage: 10,
+        source: 'signal',
+        signalId: 'sig-abc-123',
+      }, 50000);
+
+      expect(mockRpc).toHaveBeenCalledWith('execute_market_order', expect.objectContaining({
+        p_source: 'signal',
+        p_signal_id: 'sig-abc-123',
+      }));
+
+      expect(result.source).toBe('signal');
+      expect(result.signalId).toBe('sig-abc-123');
+    });
+
+    it('defaults source to manual when not provided', async () => {
+      const mockPosition = {
+        id: 'pos-1', user_id: 'user-1', asset: 'BTC', side: 'long',
+        entry_price: 50012.5, current_price: 50012.5, size: 0.1, leverage: 10,
+        margin: 500.125, liquidation_price: 45250, unrealized_pnl: 0,
+        unrealized_pnl_percent: 0, realized_pnl: 0, status: 'open',
+        opened_at: '2025-01-01T00:00:00Z', source: 'manual',
+        signal_id: null,
+      };
+
+      mockRpc.mockResolvedValue({ data: mockPosition, error: null });
+
+      const result = await executor.executeMarketOrder('user-1', {
+        asset: 'BTC',
+        side: 'long',
+        size: 0.1,
+        leverage: 10,
+      }, 50000);
+
+      expect(mockRpc).toHaveBeenCalledWith('execute_market_order', expect.objectContaining({
+        p_source: 'manual',
+        p_signal_id: null,
+      }));
+
+      expect(result.source).toBe('manual');
+    });
+  });
+
   describe('closePosition', () => {
-    it('calls RPC with correct PnL for profitable long', async () => {
+    it('deducts fees and slippage from PnL for profitable long', async () => {
       // Mock position lookup
       mockSingle.mockResolvedValue({
         data: {
@@ -258,25 +342,29 @@ describe('OrderExecutor', () => {
           margin: 5000, liquidation_price: 45250, unrealized_pnl: 0,
           unrealized_pnl_percent: 0, realized_pnl: 5000, status: 'closed',
           opened_at: '2025-01-01T00:00:00Z', closed_at: '2025-01-02T00:00:00Z',
+          source: 'manual', signal_id: null,
         },
         error: null,
       });
 
-      const result = await executor.closePosition('user-1', 'pos-1', 55000);
+      await executor.closePosition('user-1', 'pos-1', 55000);
 
-      // PnL = (55000 - 50000) * 1 = 5000
-      expect(mockRpc).toHaveBeenCalledWith('close_position_atomic', expect.objectContaining({
-        p_position_id: 'pos-1',
-        p_user_id: 'user-1',
-        p_current_price: 55000,
-        p_pnl: 5000,
-      }));
-
-      expect(result.status).toBe('closed');
-      expect(result.realizedPnl).toBe(5000);
+      // Exit notional = 1 * 55000 = 55000
+      // Exit slippage (closing long = selling = short direction): 55000 * (1 - (55000/10000)*5/10000) = ~54998.4875
+      // Entry fee = 50000 * 1 * 0.0005 = 25
+      // Exit fee = 55000 * 1 * 0.0005 = 27.5
+      // Gross PnL = (slipped_exit - 50000) * 1
+      // Net PnL = gross - 25 - 27.5
+      const rpcCall = mockRpc.mock.calls[0];
+      expect(rpcCall[0]).toBe('close_position_atomic');
+      expect(rpcCall[1].p_position_id).toBe('pos-1');
+      // PnL should be less than the naive 5000 due to fees and slippage
+      expect(rpcCall[1].p_pnl).toBeLessThan(5000);
+      // Still profitable (fees ~$52.50, slippage ~$151 on exit)
+      expect(rpcCall[1].p_pnl).toBeGreaterThan(4700);
     });
 
-    it('calculates negative PnL for losing short', async () => {
+    it('fees make losing short even worse', async () => {
       mockSingle.mockResolvedValue({
         data: {
           id: 'pos-2',
@@ -300,16 +388,16 @@ describe('OrderExecutor', () => {
           margin: 6000, liquidation_price: 3570, unrealized_pnl: 0,
           unrealized_pnl_percent: 0, realized_pnl: -2000, status: 'closed',
           opened_at: '2025-01-01T00:00:00Z', closed_at: '2025-01-02T00:00:00Z',
+          source: 'manual', signal_id: null,
         },
         error: null,
       });
 
       await executor.closePosition('user-1', 'pos-2', 3200);
 
-      // PnL = (3000 - 3200) * 10 = -2000
-      expect(mockRpc).toHaveBeenCalledWith('close_position_atomic', expect.objectContaining({
-        p_pnl: -2000,
-      }));
+      const rpcCall = mockRpc.mock.calls[0];
+      // Gross PnL is ~-2000, fees make it worse
+      expect(rpcCall[1].p_pnl).toBeLessThan(-2000);
     });
 
     it('throws ValidationError when position not found', async () => {

--- a/server/src/__tests__/pnlCalculator.test.ts
+++ b/server/src/__tests__/pnlCalculator.test.ts
@@ -241,4 +241,50 @@ describe('PnlCalculator', () => {
       expect(calc.calculateProfitFactor(trades)).toBe(1);
     });
   });
+
+  describe('calculateFee', () => {
+    it('calculates taker fee on notional', () => {
+      // $50,000 notional * 0.05% = $25
+      expect(calc.calculateFee(50000, 0.0005)).toBeCloseTo(25, 2);
+    });
+
+    it('calculates maker fee on notional', () => {
+      // $50,000 notional * 0.02% = $10
+      expect(calc.calculateFee(50000, 0.0002)).toBeCloseTo(10, 2);
+    });
+
+    it('returns 0 for zero notional', () => {
+      expect(calc.calculateFee(0, 0.0005)).toBe(0);
+    });
+  });
+
+  describe('applySlippage', () => {
+    it('slips price UP for long (buying)', () => {
+      // Notional = $10,000 → slippage = 5 bps = 0.05%
+      const slipped = calc.applySlippage(50000, 10000, 'long');
+      expect(slipped).toBeGreaterThan(50000);
+      // 50000 * (1 + 5/10000) = 50025
+      expect(slipped).toBeCloseTo(50025, 2);
+    });
+
+    it('slips price DOWN for short (selling)', () => {
+      const slipped = calc.applySlippage(50000, 10000, 'short');
+      expect(slipped).toBeLessThan(50000);
+      // 50000 * (1 - 5/10000) = 49975
+      expect(slipped).toBeCloseTo(49975, 2);
+    });
+
+    it('scales linearly with notional size', () => {
+      // $50,000 notional = 5x the slippage of $10,000
+      const small = calc.applySlippage(50000, 10000, 'long');
+      const large = calc.applySlippage(50000, 50000, 'long');
+      const smallSlip = small - 50000;
+      const largeSlip = large - 50000;
+      expect(largeSlip / smallSlip).toBeCloseTo(5, 1);
+    });
+
+    it('returns unchanged price for zero notional', () => {
+      expect(calc.applySlippage(50000, 0, 'long')).toBe(50000);
+    });
+  });
 });

--- a/server/src/__tests__/positionManager.test.ts
+++ b/server/src/__tests__/positionManager.test.ts
@@ -1,0 +1,139 @@
+import { PositionManager } from '../services/trading/positionManager';
+
+// Mock supabase - use a flexible chain that resolves on terminal methods
+const mockRpc = jest.fn();
+let mockQueryResult: { data: any; error: any } = { data: null, error: null };
+
+function makeQueryChain() {
+  const chain: any = {};
+  const returnSelf = () => chain;
+  chain.select = jest.fn(returnSelf);
+  chain.eq = jest.fn(returnSelf);
+  chain.order = jest.fn(() => Promise.resolve(mockQueryResult));
+  chain.single = jest.fn(() => Promise.resolve(mockQueryResult));
+  chain.update = jest.fn(returnSelf);
+  return chain;
+}
+
+jest.mock('../lib/supabase', () => ({
+  getSupabase: () => ({
+    from: jest.fn(() => makeQueryChain()),
+    rpc: mockRpc,
+  }),
+}));
+
+jest.mock('../lib/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+const mockDbPosition = {
+  id: 'pos-1',
+  user_id: 'user-1',
+  asset: 'BTC',
+  side: 'long',
+  entry_price: 50000,
+  current_price: 51000,
+  size: 1,
+  leverage: 10,
+  margin: 5000,
+  liquidation_price: 45250,
+  unrealized_pnl: 1000,
+  unrealized_pnl_percent: 20,
+  realized_pnl: 0,
+  status: 'open',
+  source: 'manual',
+  signal_id: null,
+  opened_at: '2025-01-01T00:00:00Z',
+};
+
+describe('PositionManager', () => {
+  let manager: PositionManager;
+
+  beforeEach(() => {
+    manager = new PositionManager();
+    jest.clearAllMocks();
+  });
+
+  describe('getOpenPositions', () => {
+    it('returns mapped positions for user', async () => {
+      mockQueryResult = { data: [mockDbPosition], error: null };
+
+      const positions = await manager.getOpenPositions('user-1');
+
+      expect(positions).toHaveLength(1);
+      expect(positions[0].id).toBe('pos-1');
+      expect(positions[0].asset).toBe('BTC');
+      expect(positions[0].source).toBe('manual');
+    });
+
+    it('returns empty array when no positions', async () => {
+      mockQueryResult = { data: [], error: null };
+
+      const positions = await manager.getOpenPositions('user-1');
+      expect(positions).toEqual([]);
+    });
+
+    it('throws on database error', async () => {
+      mockQueryResult = { data: null, error: { message: 'DB error' } };
+
+      await expect(manager.getOpenPositions('user-1')).rejects.toThrow('Failed to fetch positions');
+    });
+  });
+
+  describe('getPosition', () => {
+    it('returns position when found', async () => {
+      mockQueryResult = { data: mockDbPosition, error: null };
+
+      const position = await manager.getPosition('user-1', 'pos-1');
+
+      expect(position).not.toBeNull();
+      expect(position!.id).toBe('pos-1');
+    });
+
+    it('returns null when not found', async () => {
+      mockQueryResult = { data: null, error: { message: 'Not found' } };
+
+      const position = await manager.getPosition('user-1', 'nonexistent');
+      expect(position).toBeNull();
+    });
+  });
+
+  describe('checkLiquidations', () => {
+    it('liquidates positions below liquidation price', async () => {
+      const longPosition = {
+        ...mockDbPosition,
+        liquidation_price: 45250,
+        entry_price: 50000,
+        side: 'long',
+      };
+
+      mockQueryResult = { data: [longPosition], error: null };
+      mockRpc.mockResolvedValue({ error: null });
+
+      const prices = new Map([['BTC', 44000]]);
+      const liquidated = await manager.checkLiquidations('user-1', prices);
+
+      expect(liquidated).toHaveLength(1);
+      expect(mockRpc).toHaveBeenCalledWith('liquidate_position_atomic', { p_position_id: 'pos-1' });
+    });
+
+    it('does not liquidate positions above liquidation price', async () => {
+      mockQueryResult = { data: [mockDbPosition], error: null };
+
+      const prices = new Map([['BTC', 52000]]);
+      const liquidated = await manager.checkLiquidations('user-1', prices);
+
+      expect(liquidated).toHaveLength(0);
+      expect(mockRpc).not.toHaveBeenCalled();
+    });
+
+    it('skips assets without prices', async () => {
+      mockQueryResult = { data: [mockDbPosition], error: null };
+
+      const prices = new Map<string, number>();
+      const liquidated = await manager.checkLiquidations('user-1', prices);
+
+      expect(liquidated).toHaveLength(0);
+    });
+  });
+});

--- a/server/src/__tests__/priceService.test.ts
+++ b/server/src/__tests__/priceService.test.ts
@@ -1,0 +1,60 @@
+import { PriceService } from '../services/price/index';
+
+// Mock logger
+jest.mock('../lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe('PriceService', () => {
+  let service: PriceService;
+
+  beforeEach(() => {
+    service = new PriceService();
+  });
+
+  it('returns null when no HyperliquidService is set and no last known price', () => {
+    expect(service.getCurrentPrice('BTC')).toBeNull();
+  });
+
+  it('returns live price from HyperliquidService', () => {
+    const mockHL = {
+      getPrice: jest.fn().mockReturnValue(50000),
+      getAllPrices: jest.fn().mockReturnValue(new Map([['BTC', 50000]])),
+    };
+    service.setHyperliquidService(mockHL as any);
+
+    expect(service.getCurrentPrice('BTC')).toBe(50000);
+    expect(mockHL.getPrice).toHaveBeenCalledWith('BTC');
+  });
+
+  it('falls back to last known price when live price is 0', () => {
+    const mockHL = {
+      getPrice: jest.fn(),
+      getAllPrices: jest.fn().mockReturnValue(new Map()),
+    };
+
+    // First call: live price available
+    mockHL.getPrice.mockReturnValue(48000);
+    service.setHyperliquidService(mockHL as any);
+    service.getCurrentPrice('BTC'); // caches 48000
+
+    // Second call: live price unavailable (0)
+    mockHL.getPrice.mockReturnValue(0);
+    expect(service.getCurrentPrice('BTC')).toBe(48000);
+  });
+
+  it('returns null when live returns 0 and no last known price', () => {
+    const mockHL = {
+      getPrice: jest.fn().mockReturnValue(0),
+      getAllPrices: jest.fn().mockReturnValue(new Map()),
+    };
+    service.setHyperliquidService(mockHL as any);
+
+    expect(service.getCurrentPrice('UNKNOWN')).toBeNull();
+  });
+});

--- a/server/src/__tests__/trackerBridge.test.ts
+++ b/server/src/__tests__/trackerBridge.test.ts
@@ -1,0 +1,212 @@
+import { TrackerBridge } from '../services/tracker-bridge/index';
+import { ExternalServiceError } from '../lib/errors';
+
+// Mock logger
+jest.mock('../lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock config — tracker disabled by default
+jest.mock('../config/index', () => ({
+  config: {
+    tracker: {
+      enabled: false,
+      supabaseUrl: '',
+      supabaseKey: '',
+    },
+  },
+}));
+
+// Mock supabase client
+const mockFrom = jest.fn();
+const mockSelect = jest.fn();
+const mockEq = jest.fn();
+const mockOrder = jest.fn();
+const mockIn = jest.fn();
+const mockLimit = jest.fn();
+const mockNot = jest.fn();
+const mockHead = jest.fn();
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+// Helper to build query chain
+function makeChain(resolvedValue: { data: any; error: any; count?: number }) {
+  const chain: Record<string, jest.Mock> = {};
+  const returnSelf = () => chain;
+
+  chain.select = jest.fn().mockImplementation(returnSelf);
+  chain.eq = jest.fn().mockImplementation(returnSelf);
+  chain.in = jest.fn().mockImplementation(returnSelf);
+  chain.not = jest.fn().mockImplementation(returnSelf);
+  chain.order = jest.fn().mockImplementation(returnSelf);
+  chain.limit = jest.fn().mockImplementation(returnSelf);
+
+  // Make the chain thenable so await works
+  chain.then = jest.fn().mockImplementation((resolve) => resolve(resolvedValue));
+
+  return chain;
+}
+
+describe('TrackerBridge', () => {
+  let bridge: TrackerBridge;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when disabled', () => {
+    beforeEach(() => {
+      bridge = new TrackerBridge();
+    });
+
+    it('returns empty suggestions when disabled', async () => {
+      expect(await bridge.getSuggestedTrades()).toEqual([]);
+    });
+
+    it('returns null stats when disabled', async () => {
+      expect(await bridge.getTrackerStats()).toBeNull();
+    });
+
+    it('isEnabled returns false', () => {
+      expect(bridge.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('when enabled', () => {
+    beforeEach(() => {
+      // Override config for enabled bridge
+      const configModule = require('../config/index');
+      configModule.config.tracker.enabled = true;
+      configModule.config.tracker.supabaseUrl = 'https://test.supabase.co';
+      configModule.config.tracker.supabaseKey = 'test-key';
+
+      bridge = new TrackerBridge();
+    });
+
+    it('validates signal rows with Zod and skips invalid ones', async () => {
+      const validSignal = {
+        id: 1,
+        coin: 'BTC',
+        direction: 'long',
+        signal_tier: 'high',
+        confidence: 80,
+        avg_entry_price: 50000,
+        current_price: 51000,
+        stop_loss: 48000,
+        take_profit_1: 55000,
+        take_profit_2: null,
+        take_profit_3: null,
+        trader_count: 3,
+        created_at: new Date().toISOString(), // Fresh signal
+      };
+
+      const invalidSignal = {
+        id: 2,
+        // missing required 'coin' field
+        direction: 'long',
+        created_at: new Date().toISOString(),
+      };
+
+      const signalChain = makeChain({ data: [validSignal, invalidSignal], error: null });
+      const tradeChain = makeChain({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'quality_signals') return signalChain;
+        if (table === 'user_trades') return tradeChain;
+        return makeChain({ data: [], error: null });
+      });
+
+      const result = await bridge.getSuggestedTrades();
+
+      // Only the valid signal should be returned
+      expect(result.length).toBe(1);
+      expect(result[0].coin).toBe('BTC');
+      expect(result[0].confidence).toBe(80);
+    });
+
+    it('filters stale signals older than 24h', async () => {
+      const freshSignal = {
+        id: 1, coin: 'BTC', direction: 'long', confidence: 80,
+        avg_entry_price: 50000, current_price: 51000,
+        stop_loss: null, take_profit_1: null, take_profit_2: null, take_profit_3: null,
+        trader_count: 2, signal_tier: null,
+        created_at: new Date().toISOString(),
+      };
+
+      const staleSignal = {
+        id: 2, coin: 'ETH', direction: 'short', confidence: 90,
+        avg_entry_price: 3000, current_price: 2900,
+        stop_loss: null, take_profit_1: null, take_profit_2: null, take_profit_3: null,
+        trader_count: 1, signal_tier: null,
+        created_at: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(), // 25 hours ago
+      };
+
+      const signalChain = makeChain({ data: [freshSignal, staleSignal], error: null });
+      const tradeChain = makeChain({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'quality_signals') return signalChain;
+        if (table === 'user_trades') return tradeChain;
+        return makeChain({ data: [], error: null });
+      });
+
+      const result = await bridge.getSuggestedTrades();
+
+      expect(result.length).toBe(1);
+      expect(result[0].coin).toBe('BTC');
+    });
+
+    it('throws ExternalServiceError on DB failure', async () => {
+      const errorChain = makeChain({ data: null, error: { message: 'connection refused' } });
+      const tradeChain = makeChain({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'quality_signals') return errorChain;
+        if (table === 'user_trades') return tradeChain;
+        return makeChain({ data: [], error: null });
+      });
+
+      await expect(bridge.getSuggestedTrades()).rejects.toThrow(ExternalServiceError);
+    });
+
+    it('returns cached data when available', async () => {
+      const signal = {
+        id: 1, coin: 'BTC', direction: 'long', confidence: 80,
+        avg_entry_price: 50000, current_price: 51000,
+        stop_loss: null, take_profit_1: null, take_profit_2: null, take_profit_3: null,
+        trader_count: 2, signal_tier: null,
+        created_at: new Date().toISOString(),
+      };
+
+      const signalChain = makeChain({ data: [signal], error: null });
+      const tradeChain = makeChain({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'quality_signals') return signalChain;
+        if (table === 'user_trades') return tradeChain;
+        return makeChain({ data: [], error: null });
+      });
+
+      // First call populates cache
+      const first = await bridge.getSuggestedTrades();
+      expect(first.length).toBe(1);
+
+      // Clear mock to ensure second call doesn't hit DB
+      mockFrom.mockClear();
+
+      // Second call should use cache
+      const second = await bridge.getSuggestedTrades();
+      expect(second.length).toBe(1);
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/__tests__/websocket.test.ts
+++ b/server/src/__tests__/websocket.test.ts
@@ -1,0 +1,198 @@
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import { WebSocket, WebSocketServer as WSServer } from 'ws';
+
+// We test WebSocket functionality by creating a minimal server
+// rather than importing our WebSocketServer (which has many dependencies).
+// This tests the rate limiting and message handling logic we added.
+
+jest.mock('../lib/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+describe('WebSocket rate limiting logic', () => {
+  it('rate limit counter resets after window', () => {
+    const state = { messageCount: 0, windowStart: Date.now() - 2000 };
+    const WINDOW_MS = 1000;
+    const MAX = 20;
+
+    // Window expired, should reset
+    const now = Date.now();
+    if (now - state.windowStart >= WINDOW_MS) {
+      state.messageCount = 0;
+      state.windowStart = now;
+    }
+    state.messageCount++;
+
+    expect(state.messageCount).toBe(1);
+    expect(state.messageCount).toBeLessThanOrEqual(MAX);
+  });
+
+  it('rate limit triggers when count exceeds threshold', () => {
+    const state = { messageCount: 20, windowStart: Date.now() };
+    const MAX = 20;
+
+    state.messageCount++;
+    const isLimited = state.messageCount > MAX;
+
+    expect(isLimited).toBe(true);
+  });
+
+  it('rate limit does not trigger within threshold', () => {
+    const state = { messageCount: 0, windowStart: Date.now() };
+    const MAX = 20;
+
+    for (let i = 0; i < 20; i++) {
+      state.messageCount++;
+    }
+
+    expect(state.messageCount).toBe(20);
+    expect(state.messageCount > MAX).toBe(false);
+  });
+});
+
+describe('WebSocket server integration', () => {
+  it('accepts connections and sends messages', (done) => {
+    const server = createServer();
+    const wss = new WSServer({ server, path: '/ws' });
+
+    wss.on('connection', (ws) => {
+      ws.send(JSON.stringify({ type: 'connected', data: { clientId: 'test-123' } }));
+
+      ws.on('message', (raw) => {
+        try {
+          const msg = JSON.parse(raw.toString());
+          if (msg.type === 'subscribe') {
+            // Subscription handled
+          }
+        } catch {
+          ws.send(JSON.stringify({ type: 'error', data: { code: 'INVALID_MESSAGE', message: 'Malformed JSON' } }));
+        }
+      });
+    });
+
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      const client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+
+      client.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString());
+        expect(msg.type).toBe('connected');
+        expect(msg.data.clientId).toBe('test-123');
+
+        client.close();
+        wss.close();
+        server.close(done);
+      });
+    });
+  });
+
+  it('returns error for malformed JSON', (done) => {
+    const server = createServer();
+    const wss = new WSServer({ server, path: '/ws' });
+
+    wss.on('connection', (ws) => {
+      ws.send(JSON.stringify({ type: 'connected' }));
+      ws.on('message', (raw) => {
+        try {
+          JSON.parse(raw.toString());
+        } catch {
+          ws.send(JSON.stringify({ type: 'error', data: { code: 'INVALID_MESSAGE', message: 'Malformed JSON' } }));
+        }
+      });
+    });
+
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      const client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      let gotConnected = false;
+
+      client.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString());
+        if (!gotConnected) {
+          gotConnected = true;
+          client.send('{{not json');
+          return;
+        }
+        expect(msg.type).toBe('error');
+        expect(msg.data.code).toBe('INVALID_MESSAGE');
+        client.close();
+        wss.close();
+        server.close(done);
+      });
+    });
+  });
+
+  it('broadcasts to subscribed clients only', (done) => {
+    const server = createServer();
+    const wss = new WSServer({ server, path: '/ws' });
+    const subscriptions = new Map<WebSocket, Set<string>>();
+
+    wss.on('connection', (ws) => {
+      subscriptions.set(ws, new Set());
+      ws.send(JSON.stringify({ type: 'connected' }));
+
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === 'subscribe') {
+          subscriptions.get(ws)?.add(msg.channel);
+        }
+      });
+    });
+
+    function broadcast(channel: string, data: any) {
+      const payload = JSON.stringify({ type: 'price', channel, data });
+      for (const [ws, subs] of subscriptions) {
+        if (ws.readyState === WebSocket.OPEN && subs.has(channel)) {
+          ws.send(payload);
+        }
+      }
+    }
+
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      const sub = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      const other = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      let subReady = false;
+      let otherReady = false;
+      let otherGotMessage = false;
+
+      sub.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === 'connected') {
+          subReady = true;
+          sub.send(JSON.stringify({ type: 'subscribe', channel: 'price:BTC' }));
+          checkReady();
+          return;
+        }
+        // Should receive broadcast
+        expect(msg.data.price).toBe(42000);
+
+        // Wait a bit to confirm other didn't receive
+        setTimeout(() => {
+          expect(otherGotMessage).toBe(false);
+          sub.close();
+          other.close();
+          wss.close();
+          server.close(done);
+        }, 200);
+      });
+
+      other.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === 'connected') {
+          otherReady = true;
+          checkReady();
+          return;
+        }
+        otherGotMessage = true;
+      });
+
+      function checkReady() {
+        if (subReady && otherReady) {
+          setTimeout(() => broadcast('price:BTC', { price: 42000 }), 100);
+        }
+      }
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { leaderboardRoutes } from './routes/leaderboard.routes.js';
 import { accountRoutes } from './routes/account.routes.js';
 import { stressTestRoutes } from './routes/stressTest.routes.js';
 import { suggestionsRoutes } from './routes/suggestions.routes.js';
+import { replayRoutes } from './routes/replay.routes.js';
 
 export const app = express();
 
@@ -45,6 +46,7 @@ app.use('/api/leaderboard', leaderboardRoutes);
 app.use('/api/account', accountRoutes);
 app.use('/api/stress-test', stressTestRoutes);
 app.use('/api/suggestions', suggestionsRoutes);
+app.use('/api/replay', replayRoutes);
 
 // Error handling
 app.use(errorMiddleware);

--- a/server/src/config/constants.ts
+++ b/server/src/config/constants.ts
@@ -9,10 +9,19 @@ export const TRADING_CONSTANTS = {
   LIQUIDATION_THRESHOLD: 0.8,
 } as const;
 
+// Simplified linear slippage model for simulation purposes.
+// Real slippage is nonlinear and order-book dependent. This demonstrates
+// the execution architecture, not a production-grade market microstructure model.
+export const SLIPPAGE_BPS_PER_10K = 5; // 0.05% per $10k notional
+
 export const WS_CONSTANTS = {
   HEARTBEAT_INTERVAL: 30000,
   RECONNECT_DELAY: 3000,
   MAX_RECONNECT_ATTEMPTS: 10,
+  RATE_LIMIT: {
+    MAX_MESSAGES_PER_SECOND: 20,
+    WINDOW_MS: 1000,
+  },
 } as const;
 
 export const STRESS_TEST_CONFIG = {

--- a/server/src/lib/errors.ts
+++ b/server/src/lib/errors.ts
@@ -51,3 +51,11 @@ export class RateLimitError extends AppError {
     super(message, 429);
   }
 }
+
+export class ExternalServiceError extends AppError {
+  public service: string;
+  constructor(service: string, message: string) {
+    super(`${service}: ${message}`, 502);
+    this.service = service;
+  }
+}

--- a/server/src/routes/replay.routes.ts
+++ b/server/src/routes/replay.routes.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { authMiddleware, AuthenticatedRequest } from '../middleware/auth.middleware.js';
+import { eventService, EventType } from '../services/events/index.js';
+import { logger } from '../lib/logger.js';
+
+export const replayRoutes = Router();
+
+// GET /api/replay?from=&to=&type=&limit=
+// Returns events for the authenticated user within a time range
+replayRoutes.get('/', authMiddleware, async (req: AuthenticatedRequest, res) => {
+  try {
+    const userId = req.userId!;
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    const type = req.query.type as string | undefined;
+    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+
+    const events = await eventService.getEvents(userId, {
+      from,
+      to,
+      type: type as EventType | undefined,
+      limit: limit && !isNaN(limit) ? limit : undefined,
+    });
+
+    res.json({ events, count: events.length });
+  } catch (error) {
+    logger.error('Replay query error:', error);
+    res.status(500).json({ error: 'Failed to fetch replay events' });
+  }
+});

--- a/server/src/routes/replay.routes.ts
+++ b/server/src/routes/replay.routes.ts
@@ -13,13 +13,17 @@ replayRoutes.get('/', authMiddleware, async (req: AuthenticatedRequest, res) => 
     const from = req.query.from as string | undefined;
     const to = req.query.to as string | undefined;
     const type = req.query.type as string | undefined;
-    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+    const MAX_REPLAY_LIMIT = 1000;
+    const rawLimit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+    const limit = rawLimit != null && !isNaN(rawLimit) && rawLimit > 0
+      ? Math.min(rawLimit, MAX_REPLAY_LIMIT)
+      : undefined;
 
     const events = await eventService.getEvents(userId, {
       from,
       to,
       type: type as EventType | undefined,
-      limit: limit && !isNaN(limit) ? limit : undefined,
+      limit,
     });
 
     res.json({ events, count: events.length });

--- a/server/src/routes/suggestions.routes.ts
+++ b/server/src/routes/suggestions.routes.ts
@@ -7,6 +7,7 @@
 
 import { Router } from 'express';
 import { trackerBridge } from '../services/tracker-bridge/index.js';
+import { ExternalServiceError } from '../lib/errors.js';
 import { logger } from '../lib/logger.js';
 
 export const suggestionsRoutes = Router();
@@ -32,6 +33,13 @@ suggestionsRoutes.get('/', async (req, res) => {
       updatedAt: new Date().toISOString(),
     });
   } catch (error) {
+    if (error instanceof ExternalServiceError) {
+      logger.error(`Tracker bridge error: ${error.message}`);
+      return res.status(502).json({
+        error: 'Tracker offline',
+        details: error.message,
+      });
+    }
     logger.error('Suggestions route error:', error);
     res.status(500).json({ error: 'Failed to fetch suggestions' });
   }
@@ -47,6 +55,13 @@ suggestionsRoutes.get('/stats', async (req, res) => {
     const stats = await trackerBridge.getTrackerStats();
     res.json({ enabled: true, stats });
   } catch (error) {
+    if (error instanceof ExternalServiceError) {
+      logger.error(`Tracker bridge stats error: ${error.message}`);
+      return res.status(502).json({
+        error: 'Tracker offline',
+        details: error.message,
+      });
+    }
     logger.error('Suggestions stats error:', error);
     res.status(500).json({ error: 'Failed to fetch stats' });
   }

--- a/server/src/routes/trading.routes.ts
+++ b/server/src/routes/trading.routes.ts
@@ -87,7 +87,8 @@ tradingRoutes.get('/positions', authMiddleware, async (req: AuthenticatedRequest
     
     // Update positions with current prices
     const updatedPositions = positions.map((position) => {
-      const currentPrice = getCurrentPrice(position.asset) ?? position.entryPrice;
+      const livePrice = getCurrentPrice(position.asset);
+      const currentPrice = livePrice ?? position.entryPrice;
       const priceDiff = currentPrice - position.entryPrice;
       const direction = position.side === 'long' ? 1 : -1;
       const unrealizedPnl = priceDiff * position.size * direction;
@@ -98,6 +99,7 @@ tradingRoutes.get('/positions', authMiddleware, async (req: AuthenticatedRequest
         currentPrice,
         unrealizedPnl,
         unrealizedPnlPercent,
+        priceStale: livePrice === null, // true when price feed is unavailable
       };
     });
     

--- a/server/src/routes/trading.routes.ts
+++ b/server/src/routes/trading.routes.ts
@@ -6,7 +6,9 @@ import { OrderExecutor, PositionManager } from '../services/trading/index.js';
 import { LeaderboardService } from '../services/leaderboard/index.js';
 import { getSupabase } from '../lib/supabase.js';
 import { logger } from '../lib/logger.js';
+import { priceService } from '../services/price/index.js';
 import type { HyperliquidService } from '../services/hyperliquid/index.js';
+import { eventService } from '../services/events/index.js';
 
 export const tradingRoutes = Router();
 
@@ -14,6 +16,7 @@ let hyperliquidService: HyperliquidService | null = null;
 
 export function setHyperliquidService(service: HyperliquidService) {
   hyperliquidService = service;
+  priceService.setHyperliquidService(service);
 }
 
 const orderExecutor = new OrderExecutor();
@@ -25,25 +28,17 @@ const placeOrderSchema = z.object({
   side: z.enum(['long', 'short']),
   size: z.number().positive(),
   leverage: z.number().min(1).max(50),
+  source: z.enum(['manual', 'signal']).optional(),
+  signalId: z.string().optional(),
 });
 
 const positionIdSchema = z.object({
   id: z.string().uuid(),
 });
 
-// Helper to get current price from Hyperliquid or fallback
-function getCurrentPrice(asset: string): number {
-  if (hyperliquidService) {
-    const price = hyperliquidService.getPrice(asset);
-    if (price > 0) return price;
-  }
-  // Fallback prices if service unavailable
-  const fallbackPrices: Record<string, number> = {
-    BTC: 87500,
-    ETH: 2900,
-    SOL: 120,
-  };
-  return fallbackPrices[asset] || 100;
+// Get current price via PriceService (live WS → last known → null)
+function getCurrentPrice(asset: string): number | null {
+  return priceService.getCurrentPrice(asset);
 }
 
 // Place market order
@@ -53,17 +48,20 @@ tradingRoutes.post(
   validateBody(placeOrderSchema),
   async (req: AuthenticatedRequest, res) => {
     try {
-      const { asset, side, size, leverage } = req.body;
+      const { asset, side, size, leverage, source, signalId } = req.body;
       const userId = req.userId!;
 
-      logger.info(`Order request: ${side} ${size} ${asset} @ ${leverage}x for user ${userId}`);
+      logger.info(`Order request: ${side} ${size} ${asset} @ ${leverage}x for user ${userId} (source: ${source || 'manual'})`);
 
       const currentPrice = getCurrentPrice(asset);
+      if (currentPrice === null) {
+        return res.status(503).json({ error: 'Price feed unavailable', details: `No price data for ${asset}` });
+      }
       logger.info(`Current price for ${asset}: ${currentPrice}`);
 
       const position = await orderExecutor.executeMarketOrder(
         userId,
-        { asset, side, size, leverage },
+        { asset, side, size, leverage, source, signalId },
         currentPrice
       );
 
@@ -89,12 +87,12 @@ tradingRoutes.get('/positions', authMiddleware, async (req: AuthenticatedRequest
     
     // Update positions with current prices
     const updatedPositions = positions.map((position) => {
-      const currentPrice = getCurrentPrice(position.asset);
+      const currentPrice = getCurrentPrice(position.asset) ?? position.entryPrice;
       const priceDiff = currentPrice - position.entryPrice;
       const direction = position.side === 'long' ? 1 : -1;
       const unrealizedPnl = priceDiff * position.size * direction;
       const unrealizedPnlPercent = (priceDiff / position.entryPrice) * 100 * direction * position.leverage;
-      
+
       return {
         ...position,
         currentPrice,
@@ -127,8 +125,23 @@ tradingRoutes.post(
       }
 
       const currentPrice = getCurrentPrice(position.asset);
+      if (currentPrice === null) {
+        return res.status(503).json({ error: 'Price feed unavailable', details: `No price data for ${position.asset}` });
+      }
 
       const closedPosition = await orderExecutor.closePosition(userId, id, currentPrice);
+
+      // Emit position_closed event (post-fee PnL)
+      await eventService.emit('position_closed', {
+        positionId: id,
+        asset: closedPosition.asset,
+        side: closedPosition.side,
+        entryPrice: closedPosition.entryPrice,
+        exitPrice: currentPrice,
+        size: closedPosition.size,
+        realizedPnl: closedPosition.realizedPnl,
+        source: closedPosition.source,
+      }, userId);
 
       // Update leaderboard stats
       await leaderboardService.updateUserStats(userId);

--- a/server/src/services/events/index.ts
+++ b/server/src/services/events/index.ts
@@ -1,0 +1,86 @@
+import { getSupabase } from '../../lib/supabase.js';
+import { logger } from '../../lib/logger.js';
+
+export type EventType =
+  | 'trade_executed'
+  | 'position_closed'
+  | 'signal_received'
+  | 'price_tick'
+  | 'pnl_update';
+
+export interface TradingEvent {
+  id?: string;
+  type: EventType;
+  payload: Record<string, unknown>;
+  userId?: string;
+  sessionId?: string;
+  createdAt?: string;
+}
+
+export class EventService {
+  // Emit uses await for reliability, not fire-and-forget.
+  // This ensures replay data integrity at the cost of ~1-2ms per event.
+  async emit(type: EventType, payload: Record<string, unknown>, userId?: string, sessionId?: string): Promise<void> {
+    try {
+      const supabase = getSupabase();
+      const { error } = await supabase
+        .from('events')
+        .insert({
+          type,
+          payload,
+          user_id: userId || null,
+          session_id: sessionId || null,
+        });
+
+      if (error) {
+        logger.error(`[EventService] Failed to emit ${type}:`, error.message);
+      }
+    } catch (error) {
+      logger.error(`[EventService] Exception emitting ${type}:`, error);
+    }
+  }
+
+  async getEvents(
+    userId: string,
+    options?: { from?: string; to?: string; type?: EventType; limit?: number }
+  ): Promise<TradingEvent[]> {
+    const supabase = getSupabase();
+
+    let query = supabase
+      .from('events')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: true });
+
+    if (options?.from) {
+      query = query.gte('created_at', options.from);
+    }
+    if (options?.to) {
+      query = query.lte('created_at', options.to);
+    }
+    if (options?.type) {
+      query = query.eq('type', options.type);
+    }
+    if (options?.limit) {
+      query = query.limit(options.limit);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      logger.error('[EventService] Failed to fetch events:', error.message);
+      return [];
+    }
+
+    return (data || []).map((row: Record<string, unknown>) => ({
+      id: row.id as string,
+      type: row.type as EventType,
+      payload: row.payload as Record<string, unknown>,
+      userId: row.user_id as string,
+      sessionId: row.session_id as string | undefined,
+      createdAt: row.created_at as string,
+    }));
+  }
+}
+
+export const eventService = new EventService();

--- a/server/src/services/price/index.ts
+++ b/server/src/services/price/index.ts
@@ -1,0 +1,46 @@
+import type { HyperliquidService } from '../hyperliquid/index.js';
+import { logger } from '../../lib/logger.js';
+
+// Single source of truth for current asset prices.
+// Fallback chain: live WebSocket price → last known price → null (reject trade).
+// No hardcoded prices. If we don't have data, we say so.
+export class PriceService {
+  private hyperliquidService: HyperliquidService | null = null;
+  private lastKnownPrices: Map<string, number> = new Map();
+
+  setHyperliquidService(service: HyperliquidService) {
+    this.hyperliquidService = service;
+  }
+
+  getCurrentPrice(asset: string): number | null {
+    // Try live WebSocket price first
+    if (this.hyperliquidService) {
+      const livePrice = this.hyperliquidService.getPrice(asset);
+      if (livePrice > 0) {
+        this.lastKnownPrices.set(asset, livePrice);
+        return livePrice;
+      }
+    }
+
+    // Fall back to last known price
+    const lastKnown = this.lastKnownPrices.get(asset);
+    if (lastKnown && lastKnown > 0) {
+      logger.warn(`Using last known price for ${asset}: ${lastKnown}`);
+      return lastKnown;
+    }
+
+    // No price available
+    logger.error(`No price available for ${asset}`);
+    return null;
+  }
+
+  getAllPrices(): Map<string, number> {
+    if (this.hyperliquidService) {
+      return this.hyperliquidService.getAllPrices();
+    }
+    return this.lastKnownPrices;
+  }
+}
+
+// Singleton
+export const priceService = new PriceService();

--- a/server/src/services/tracker-bridge/index.ts
+++ b/server/src/services/tracker-bridge/index.ts
@@ -9,8 +9,47 @@
 // ============================================
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { z } from 'zod';
 import { config } from '../../config/index.js';
 import { logger } from '../../lib/logger.js';
+import { ExternalServiceError } from '../../lib/errors.js';
+import { eventService } from '../events/index.js';
+
+// Zod schemas for external data validation
+const signalRowSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  coin: z.string(),
+  direction: z.enum(['long', 'short']),
+  signal_tier: z.string().nullable().optional(),
+  confidence: z.number().nullable().optional(),
+  avg_entry_price: z.number().nullable().optional(),
+  current_price: z.number().nullable().optional(),
+  stop_loss: z.number().nullable().optional(),
+  take_profit_1: z.number().nullable().optional(),
+  take_profit_2: z.number().nullable().optional(),
+  take_profit_3: z.number().nullable().optional(),
+  trader_count: z.number().nullable().optional(),
+  created_at: z.string(),
+});
+
+const tradeRowSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  coin: z.string(),
+  direction: z.enum(['long', 'short']),
+  confidence_at_entry: z.number().nullable().optional(),
+  user_entry_price: z.number().nullable().optional(),
+  current_price: z.number().nullable().optional(),
+  stop_loss: z.number().nullable().optional(),
+  take_profit_1: z.number().nullable().optional(),
+  take_profit_2: z.number().nullable().optional(),
+  take_profit_3: z.number().nullable().optional(),
+  kelly_fraction: z.number().nullable().optional(),
+  position_size_usd: z.number().nullable().optional(),
+  trader_address: z.string().nullable().optional(),
+  trader_tier: z.string().nullable().optional(),
+  opened_at: z.string(),
+  source: z.string(),
+});
 
 export interface SuggestedTrade {
   id: string;
@@ -34,9 +73,12 @@ export interface SuggestedTrade {
   source: string;
 }
 
+const STALENESS_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+
 export class TrackerBridge {
   private client: SupabaseClient | null = null;
   private cache: { data: SuggestedTrade[]; expiresAt: number } | null = null;
+  private lastSeenSignalIds: Set<string> = new Set();
   private readonly CACHE_TTL_MS = 30_000; // 30 seconds
 
   constructor() {
@@ -75,12 +117,35 @@ export class TrackerBridge {
       // Sort by confidence descending
       suggestions.sort((a, b) => b.confidence - a.confidence);
 
+      // Emit signal_received only for newly-appeared signals (deduplicate across refreshes)
+      const currentSignalIds = new Set(signals.map(s => s.id));
+      for (const s of signals) {
+        if (!this.lastSeenSignalIds.has(s.id)) {
+          eventService.emit('signal_received', {
+            signalId: s.id,
+            coin: s.coin,
+            direction: s.direction,
+            confidence: s.confidence,
+            entryPrice: s.entryPrice,
+            source: s.source,
+          }).catch(() => {}); // Non-blocking for bridge reads
+        }
+      }
+      this.lastSeenSignalIds = currentSignalIds;
+
       this.cache = { data: suggestions, expiresAt: Date.now() + this.CACHE_TTL_MS };
       return suggestions;
     } catch (error) {
+      if (error instanceof ExternalServiceError) throw error;
       logger.error('[TrackerBridge] Error fetching suggestions:', error);
+      // Return stale cache on error
       return this.cache?.data || [];
     }
+  }
+
+  private isStale(dateStr: string): boolean {
+    const created = new Date(dateStr).getTime();
+    return Date.now() - created > STALENESS_THRESHOLD_MS;
   }
 
   private async getActiveSignals(): Promise<SuggestedTrade[]> {
@@ -93,31 +158,45 @@ export class TrackerBridge {
       .order('confidence', { ascending: false });
 
     if (error) {
-      logger.error('[TrackerBridge] Error fetching signals:', error.message);
-      return [];
+      throw new ExternalServiceError('TrackerBridge', `Failed to fetch signals: ${error.message}`);
     }
 
-    return (data || []).map(s => ({
-      id: `signal-${s.id}`,
-      type: 'signal' as const,
-      coin: s.coin,
-      direction: s.direction,
-      confidence: s.confidence || 0,
-      entryPrice: s.avg_entry_price || 0,
-      currentPrice: s.current_price || s.avg_entry_price || 0,
-      stopLoss: s.stop_loss,
-      takeProfit1: s.take_profit_1,
-      takeProfit2: s.take_profit_2,
-      takeProfit3: s.take_profit_3,
-      traderCount: s.trader_count || 1,
-      signalTier: s.signal_tier,
-      kellyFraction: null,
-      positionSizeUsd: null,
-      traderAddress: null,
-      traderTier: null,
-      openedAt: s.created_at,
-      source: 'convergence',
-    }));
+    const validated: SuggestedTrade[] = [];
+    for (const row of data || []) {
+      const parsed = signalRowSchema.safeParse(row);
+      if (!parsed.success) {
+        logger.warn('[TrackerBridge] Invalid signal row, skipping:', parsed.error.message);
+        continue;
+      }
+      const s = parsed.data;
+
+      // Filter stale signals (older than 24h)
+      if (this.isStale(s.created_at)) continue;
+
+      validated.push({
+        id: `signal-${s.id}`,
+        type: 'signal',
+        coin: s.coin,
+        direction: s.direction,
+        confidence: s.confidence || 0,
+        entryPrice: s.avg_entry_price || 0,
+        currentPrice: s.current_price || s.avg_entry_price || 0,
+        stopLoss: s.stop_loss ?? null,
+        takeProfit1: s.take_profit_1 ?? null,
+        takeProfit2: s.take_profit_2 ?? null,
+        takeProfit3: s.take_profit_3 ?? null,
+        traderCount: s.trader_count || 1,
+        signalTier: s.signal_tier ?? null,
+        kellyFraction: null,
+        positionSizeUsd: null,
+        traderAddress: null,
+        traderTier: null,
+        openedAt: s.created_at,
+        source: 'convergence',
+      });
+    }
+
+    return validated;
   }
 
   private async getActivePositionTrades(): Promise<SuggestedTrade[]> {
@@ -133,31 +212,45 @@ export class TrackerBridge {
       .limit(50);
 
     if (error) {
-      logger.error('[TrackerBridge] Error fetching position trades:', error.message);
-      return [];
+      throw new ExternalServiceError('TrackerBridge', `Failed to fetch trades: ${error.message}`);
     }
 
-    return (data || []).map(t => ({
-      id: `trade-${t.id}`,
-      type: 'position' as const,
-      coin: t.coin,
-      direction: t.direction,
-      confidence: t.confidence_at_entry || 0,
-      entryPrice: t.user_entry_price || 0,
-      currentPrice: t.current_price || t.user_entry_price || 0,
-      stopLoss: t.stop_loss,
-      takeProfit1: t.take_profit_1,
-      takeProfit2: t.take_profit_2,
-      takeProfit3: t.take_profit_3,
-      traderCount: 1,
-      signalTier: null,
-      kellyFraction: t.kelly_fraction,
-      positionSizeUsd: t.position_size_usd,
-      traderAddress: t.trader_address,
-      traderTier: t.trader_tier,
-      openedAt: t.opened_at,
-      source: t.source === 'system' ? 'signal_trade' : 'position_trade',
-    }));
+    const validated: SuggestedTrade[] = [];
+    for (const row of data || []) {
+      const parsed = tradeRowSchema.safeParse(row);
+      if (!parsed.success) {
+        logger.warn('[TrackerBridge] Invalid trade row, skipping:', parsed.error.message);
+        continue;
+      }
+      const t = parsed.data;
+
+      // Filter stale trades (older than 24h)
+      if (this.isStale(t.opened_at)) continue;
+
+      validated.push({
+        id: `trade-${t.id}`,
+        type: 'position',
+        coin: t.coin,
+        direction: t.direction,
+        confidence: t.confidence_at_entry || 0,
+        entryPrice: t.user_entry_price || 0,
+        currentPrice: t.current_price || t.user_entry_price || 0,
+        stopLoss: t.stop_loss ?? null,
+        takeProfit1: t.take_profit_1 ?? null,
+        takeProfit2: t.take_profit_2 ?? null,
+        takeProfit3: t.take_profit_3 ?? null,
+        traderCount: 1,
+        signalTier: null,
+        kellyFraction: t.kelly_fraction ?? null,
+        positionSizeUsd: t.position_size_usd ?? null,
+        traderAddress: t.trader_address ?? null,
+        traderTier: t.trader_tier ?? null,
+        openedAt: t.opened_at,
+        source: t.source === 'system' ? 'signal_trade' : 'position_trade',
+      });
+    }
+
+    return validated;
   }
 
   async getTrackerStats(): Promise<{
@@ -170,13 +263,12 @@ export class TrackerBridge {
     if (!this.client) return null;
 
     try {
-      const [signals, traders, closedSignals] = await Promise.all([
+      const [signals, traders, closedSignals, activeCount] = await Promise.all([
         this.client.from('quality_signals').select('id', { count: 'exact', head: true }),
         this.client.from('trader_quality').select('id', { count: 'exact', head: true }).eq('is_tracked', true),
         this.client.from('quality_signals').select('outcome').eq('is_active', false).not('outcome', 'is', null),
+        this.client.from('quality_signals').select('id', { count: 'exact', head: true }).eq('is_active', true),
       ]);
-
-      const activeCount = await this.client.from('quality_signals').select('id', { count: 'exact', head: true }).eq('is_active', true);
 
       let signalWinRate: number | null = null;
       if (closedSignals.data && closedSignals.data.length > 0) {
@@ -189,11 +281,10 @@ export class TrackerBridge {
         activeSignals: activeCount.count || 0,
         trackedTraders: traders.count || 0,
         signalWinRate,
-        positionWinRate: null, // TODO: compute from user_trades
+        positionWinRate: null,
       };
     } catch (error) {
-      logger.error('[TrackerBridge] Error fetching stats:', error);
-      return null;
+      throw new ExternalServiceError('TrackerBridge', `Failed to fetch stats: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 }

--- a/server/src/services/trading/orderExecutor.ts
+++ b/server/src/services/trading/orderExecutor.ts
@@ -172,7 +172,10 @@ export class OrderExecutor {
     const exitSide = position.side === 'long' ? 'short' : 'long'; // Closing reverses direction
     const slippedExitPrice = this.pnlCalculator.applySlippage(currentPrice, exitNotional, exitSide as OrderSide);
 
-    // Calculate fees: entry fee was already "paid" at open, exit fee deducted now
+    // Fee model: both entry and exit fees are deducted from PnL at close time.
+    // Entry fee is NOT deducted from balance at open (only margin is). This matches
+    // how most perp exchanges work: fees come from realized PnL, not upfront balance.
+    // This is not double-counting. The entry fee is calculated once here, not at open.
     const entryNotional = position.size * position.entry_price;
     const entryFee = this.pnlCalculator.calculateFee(entryNotional, TRADING_CONSTANTS.TAKER_FEE);
     const exitFee = this.pnlCalculator.calculateFee(exitNotional, TRADING_CONSTANTS.TAKER_FEE);

--- a/server/src/services/trading/orderExecutor.ts
+++ b/server/src/services/trading/orderExecutor.ts
@@ -6,6 +6,7 @@ import { isValidAsset } from '../../config/assets.js';
 import { PnlCalculator } from './pnlCalculator.js';
 import type { Position, PlaceOrderRequest, OrderSide } from '../../types/trading.js';
 import { logger } from '../../lib/logger.js';
+import { eventService } from '../events/index.js';
 
 export class OrderExecutor {
   private pnlCalculator: PnlCalculator;
@@ -79,16 +80,23 @@ export class OrderExecutor {
     // Ensure account exists before calling RPC
     await this.getOrCreateAccount(userId);
 
-    // Calculate values
+    // Apply slippage to entry price (buys slip up, sells slip down)
     const notionalValue = size * currentPrice;
-    const marginRequired = notionalValue / leverage;
+    const slippedPrice = this.pnlCalculator.applySlippage(currentPrice, notionalValue, side);
+
+    // Calculate entry fee (taker fee for market orders)
+    const entryFee = this.pnlCalculator.calculateFee(notionalValue, TRADING_CONSTANTS.TAKER_FEE);
+
+    // Calculate margin based on slipped price
+    const slippedNotional = size * slippedPrice;
+    const marginRequired = slippedNotional / leverage;
     const liquidationPrice = this.pnlCalculator.calculateLiquidationPrice(
-      currentPrice,
+      slippedPrice,
       leverage,
       side
     );
 
-    logger.info(`Notional: ${notionalValue}, Margin required: ${marginRequired}`);
+    logger.info(`Notional: ${notionalValue}, Slipped price: ${slippedPrice}, Fee: ${entryFee}, Margin: ${marginRequired}`);
 
     const positionId = uuidv4();
     const supabase = getSupabase();
@@ -100,11 +108,13 @@ export class OrderExecutor {
       p_user_id: userId,
       p_asset: asset,
       p_side: side,
-      p_entry_price: currentPrice,
+      p_entry_price: slippedPrice,
       p_size: size,
       p_leverage: leverage,
       p_margin: marginRequired,
       p_liquidation_price: liquidationPrice,
+      p_source: request.source || 'manual',
+      p_signal_id: request.signalId || null,
     });
 
     if (error) {
@@ -118,7 +128,23 @@ export class OrderExecutor {
 
     logger.info(`Position created atomically: ${positionId}`);
 
-    return this.mapDbPosition(data);
+    const position = this.mapDbPosition(data);
+
+    // Emit trade_executed event (post-fee numbers)
+    await eventService.emit('trade_executed', {
+      positionId,
+      asset,
+      side,
+      size,
+      entryPrice: slippedPrice,
+      leverage,
+      margin: marginRequired,
+      entryFee,
+      source: request.source || 'manual',
+      signalId: request.signalId || null,
+    }, userId);
+
+    return position;
   }
 
   async closePosition(
@@ -141,17 +167,29 @@ export class OrderExecutor {
       throw new ValidationError('Position not found');
     }
 
-    // Calculate PnL
-    const pnl = this.pnlCalculator.calculatePnl(
+    // Apply slippage to exit price
+    const exitNotional = position.size * currentPrice;
+    const exitSide = position.side === 'long' ? 'short' : 'long'; // Closing reverses direction
+    const slippedExitPrice = this.pnlCalculator.applySlippage(currentPrice, exitNotional, exitSide as OrderSide);
+
+    // Calculate fees: entry fee was already "paid" at open, exit fee deducted now
+    const entryNotional = position.size * position.entry_price;
+    const entryFee = this.pnlCalculator.calculateFee(entryNotional, TRADING_CONSTANTS.TAKER_FEE);
+    const exitFee = this.pnlCalculator.calculateFee(exitNotional, TRADING_CONSTANTS.TAKER_FEE);
+    const totalFees = entryFee + exitFee;
+
+    // Calculate PnL (net of fees)
+    const grossPnl = this.pnlCalculator.calculatePnl(
       position.entry_price,
-      currentPrice,
+      slippedExitPrice,
       position.size,
       position.side as OrderSide
     );
+    const pnl = grossPnl - totalFees;
 
     const pnlPercent = this.pnlCalculator.calculatePnlPercent(
       position.entry_price,
-      currentPrice,
+      slippedExitPrice,
       position.side as OrderSide,
       position.leverage
     );
@@ -195,6 +233,8 @@ export class OrderExecutor {
       unrealizedPnlPercent: db.unrealized_pnl_percent as number,
       realizedPnl: db.realized_pnl as number,
       status: db.status as Position['status'],
+      source: (db.source as Position['source']) || 'manual',
+      signalId: db.signal_id as string | undefined,
       openedAt: db.opened_at as string,
       closedAt: db.closed_at as string | undefined,
     };

--- a/server/src/services/trading/pnlCalculator.ts
+++ b/server/src/services/trading/pnlCalculator.ts
@@ -1,4 +1,4 @@
-import { TRADING_CONSTANTS } from '../../config/constants.js';
+import { TRADING_CONSTANTS, SLIPPAGE_BPS_PER_10K } from '../../config/constants.js';
 import type { OrderSide } from '../../types/trading.js';
 
 export class PnlCalculator {
@@ -93,5 +93,20 @@ export class PnlCalculator {
       trades.filter((t) => t.pnl < 0).reduce((sum, t) => sum + t.pnl, 0)
     );
     return grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? Infinity : 0;
+  }
+
+  calculateFee(notional: number, feeRate: number): number {
+    return notional * feeRate;
+  }
+
+  // Simplified linear slippage: 0.05% per $10k notional.
+  // Direction: buys slip up, sells slip down.
+  applySlippage(price: number, notional: number, side: OrderSide): number {
+    const slippageBps = (notional / 10_000) * SLIPPAGE_BPS_PER_10K;
+    const slippageFraction = slippageBps / 10_000;
+    if (side === 'long') {
+      return price * (1 + slippageFraction);
+    }
+    return price * (1 - slippageFraction);
   }
 }

--- a/server/src/services/trading/positionManager.ts
+++ b/server/src/services/trading/positionManager.ts
@@ -149,6 +149,8 @@ export class PositionManager {
       unrealizedPnlPercent: db.unrealized_pnl_percent as number,
       realizedPnl: db.realized_pnl as number,
       status: db.status as Position['status'],
+      source: (db.source as Position['source']) || 'manual',
+      signalId: db.signal_id as string | undefined,
       openedAt: db.opened_at as string,
       closedAt: db.closed_at as string | undefined,
     };

--- a/server/src/types/trading.ts
+++ b/server/src/types/trading.ts
@@ -1,6 +1,8 @@
 export type OrderSide = 'long' | 'short';
 export type PositionStatus = 'open' | 'closed' | 'liquidated';
 
+export type PositionSource = 'manual' | 'signal';
+
 export interface Position {
   id: string;
   userId: string;
@@ -16,6 +18,8 @@ export interface Position {
   unrealizedPnlPercent: number;
   realizedPnl: number;
   status: PositionStatus;
+  source: PositionSource;
+  signalId?: string;
   openedAt: string;
   closedAt?: string;
 }
@@ -52,6 +56,8 @@ export interface PlaceOrderRequest {
   side: OrderSide;
   size: number;
   leverage: number;
+  source?: PositionSource;
+  signalId?: string;
 }
 
 export interface ClosePositionRequest {

--- a/server/src/websocket/index.ts
+++ b/server/src/websocket/index.ts
@@ -6,9 +6,14 @@ import { WS_CONSTANTS } from '../config/constants.js';
 import { getSupabase } from '../lib/supabase.js';
 import type { WSMessage, ClientConnection } from '../types/websocket.js';
 
+interface RateLimitState {
+  messageCount: number;
+  windowStart: number;
+}
+
 export class WebSocketServer {
   private wss: WSServer;
-  private clients: Map<string, { ws: WebSocket; connection: ClientConnection }> = new Map();
+  private clients: Map<string, { ws: WebSocket; connection: ClientConnection; rateLimit: RateLimitState }> = new Map();
   private heartbeatInterval: NodeJS.Timeout | null = null;
 
   constructor(server: Server) {
@@ -43,18 +48,38 @@ export class WebSocketServer {
         }
       }
 
-      this.clients.set(clientId, { ws, connection });
+      const rateLimit: RateLimitState = { messageCount: 0, windowStart: Date.now() };
+      this.clients.set(clientId, { ws, connection, rateLimit });
       logger.info(`Client connected: ${clientId}`);
 
       // Send connected message
       this.send(ws, { type: 'connected', data: { clientId } });
 
       ws.on('message', (data) => {
+        const client = this.clients.get(clientId);
+        if (!client) return;
+
+        // Rate limiting: per-connection message throttle
+        const now = Date.now();
+        const rl = client.rateLimit;
+        if (now - rl.windowStart >= WS_CONSTANTS.RATE_LIMIT.WINDOW_MS) {
+          rl.messageCount = 0;
+          rl.windowStart = now;
+        }
+        rl.messageCount++;
+
+        if (rl.messageCount > WS_CONSTANTS.RATE_LIMIT.MAX_MESSAGES_PER_SECOND) {
+          this.send(ws, { type: 'error', data: { code: 'RATE_LIMITED', message: 'Too many messages, disconnecting' } });
+          logger.warn(`Rate limited client ${clientId}: ${rl.messageCount} msgs in window`);
+          ws.close(1008, 'Rate limited');
+          return;
+        }
+
         try {
           const message: WSMessage = JSON.parse(data.toString());
           this.handleMessage(clientId, message);
         } catch (error) {
-          logger.error('Invalid WebSocket message:', error);
+          this.send(ws, { type: 'error', data: { code: 'INVALID_MESSAGE', message: 'Malformed JSON' } });
         }
       });
 

--- a/supabase/migrations/008_add_source_to_positions.sql
+++ b/supabase/migrations/008_add_source_to_positions.sql
@@ -1,0 +1,66 @@
+-- Add source attribution to positions
+-- Tracks whether a position was opened manually or from a tracker signal
+ALTER TABLE positions ADD COLUMN IF NOT EXISTS source VARCHAR(20) DEFAULT 'manual';
+ALTER TABLE positions ADD COLUMN IF NOT EXISTS signal_id UUID;
+
+-- Update the execute_market_order function to accept source and signal_id
+CREATE OR REPLACE FUNCTION execute_market_order(
+  p_position_id UUID,
+  p_user_id UUID,
+  p_asset VARCHAR,
+  p_side VARCHAR,
+  p_entry_price DECIMAL,
+  p_size DECIMAL,
+  p_leverage INTEGER,
+  p_margin DECIMAL,
+  p_liquidation_price DECIMAL,
+  p_source VARCHAR DEFAULT 'manual',
+  p_signal_id UUID DEFAULT NULL
+)
+RETURNS JSON AS $$
+DECLARE
+  v_account RECORD;
+  v_new_balance DECIMAL;
+  v_position RECORD;
+BEGIN
+  -- Lock the account row to prevent concurrent modifications
+  SELECT * INTO v_account
+  FROM accounts
+  WHERE user_id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Account not found for user %', p_user_id;
+  END IF;
+
+  -- Check sufficient balance
+  IF v_account.balance < p_margin THEN
+    RAISE EXCEPTION 'Insufficient margin. Required: %, Available: %', p_margin, v_account.balance;
+  END IF;
+
+  -- Deduct margin from balance
+  v_new_balance := v_account.balance - p_margin;
+  UPDATE accounts SET balance = v_new_balance, updated_at = NOW()
+  WHERE user_id = p_user_id;
+
+  -- Create position with source attribution
+  INSERT INTO positions (
+    id, user_id, asset, side, entry_price, current_price,
+    size, leverage, margin, liquidation_price,
+    unrealized_pnl, unrealized_pnl_percent, realized_pnl,
+    status, opened_at, source, signal_id
+  ) VALUES (
+    p_position_id, p_user_id, p_asset, p_side, p_entry_price, p_entry_price,
+    p_size, p_leverage, p_margin, p_liquidation_price,
+    0, 0, 0,
+    'open', NOW(), p_source, p_signal_id
+  )
+  RETURNING * INTO v_position;
+
+  -- Return position data as JSON
+  RETURN row_to_json(v_position);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Re-grant execute permissions
+GRANT EXECUTE ON FUNCTION execute_market_order TO authenticated;

--- a/supabase/migrations/009_create_events_table.sql
+++ b/supabase/migrations/009_create_events_table.sql
@@ -1,0 +1,30 @@
+-- Event sourcing foundation: append-only audit log for replay engine
+-- This is an audit log with time-range queries, not deterministic event sourcing
+-- with full replay guarantees. Events capture post-fee PnL numbers.
+CREATE TABLE IF NOT EXISTS events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  type VARCHAR(50) NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}',
+  user_id UUID,
+  session_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for replay queries: fetch events for a user within a time range
+CREATE INDEX IF NOT EXISTS idx_events_user_created ON events (user_id, created_at);
+
+-- Index for event type filtering
+CREATE INDEX IF NOT EXISTS idx_events_type ON events (type);
+
+-- RLS: users can only read their own events
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own events" ON events
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Service role can insert events" ON events
+  FOR INSERT WITH CHECK (true);
+
+-- Grant access
+GRANT SELECT ON events TO authenticated;
+GRANT INSERT ON events TO authenticated;

--- a/supabase/migrations/010_harden_rls_and_constraints.sql
+++ b/supabase/migrations/010_harden_rls_and_constraints.sql
@@ -1,0 +1,21 @@
+-- Hardening: fix events RLS and add source CHECK constraint
+-- Addresses adversarial review findings #3 and #7
+
+-- #3: Events INSERT policy was WITH CHECK (true), allowing any authenticated
+-- user to insert events with any user_id. The server uses service role
+-- (bypasses RLS), so remove the authenticated INSERT grant entirely.
+REVOKE INSERT ON events FROM authenticated;
+
+DROP POLICY IF EXISTS "Service role can insert events" ON events;
+
+-- Service role bypasses RLS, no explicit policy needed for server-side inserts.
+-- If we ever need client-side event insertion, add:
+--   CREATE POLICY "Users can insert own events" ON events
+--     FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- #7: Add CHECK constraint on positions.source column
+-- Backfill any NULL values from before migration 008 added the column
+UPDATE positions SET source = 'manual' WHERE source IS NULL;
+
+ALTER TABLE positions ADD CONSTRAINT positions_source_check
+  CHECK (source IN ('manual', 'signal'));


### PR DESCRIPTION
## Summary

Full tracker bridge integration with event sourcing, execution hardening, and comprehensive test coverage.

**Bridge Integration**
- Signal → Trade flow with "Take Trade" confirmation modal and SIG badge
- Source attribution (manual/signal) persisted through positions table
- Signal event deduplication via lastSeenSignalIds Set

**Execution Model**
- Realistic fee calculation (0.05% taker fee) wired into execution
- Linear slippage model (5 BPS per $10k notional)
- Notional-based trade sizing ($500 default) for consistent margin exposure

**Event Sourcing**
- Append-only events table with RLS (user reads own, service role inserts)
- Await-based emission for replay data integrity
- Replay API with time-range queries, type filtering, pagination cap (1000)
- Events emitted on trade_executed, position_closed, signal_received

**Infrastructure**
- Unified PriceService (live WS → last known → null)
- WebSocket rate limiting (20 msg/sec per connection)
- Bridge hardening: Zod validation, 24h staleness filter, typed errors
- ExternalServiceError class for consistent error patterns

**Hardening (adversarial review)**
- Fix events table RLS: revoke INSERT from authenticated (prevents cross-user injection)
- Replay pagination cap with negative/zero limit guard
- priceStale flag on positions response
- CHECK constraint on positions.source (manual/signal)
- Fee model documentation (fees deduct from PnL at close, not double-counted)

## Test Coverage
- 118 tests across 9 suites, all passing
- Suites: orderExecutor, pnlCalculator, priceService, eventService, trackerBridge, websocket, middleware, positionManager, calculations

## Pre-Landing Review
Pre-Landing Review: 2 issues auto-fixed (negative limit bypass, NULL backfill in migration)

## Adversarial Review
8 findings triaged: 4 fixed in code, 2 documented, 2 confirmed already addressed/intentional

## Test plan
- [x] All Jest tests pass (118 tests, 9 suites, 0 failures)
- [x] TypeScript typecheck clean
- [x] Eng review CLEARED
- [x] Adversarial review CLEARED

🤖 Generated with [Claude Code](https://claude.com/claude-code)