### PR TITLE
docs: mark hosted demo offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A full-stack paper trading platform powered by real-time Hyperliquid and Binance market data. Trade 70+ crypto perpetual futures with $100k virtual USDC, track PnL with proper margin and liquidation math, and compete on a global leaderboard, all backed by Supabase with atomic database transactions and live WebSocket streaming.
 
-**[Trade Now &rarr; tradeterm.app](https://tradeterm.app/)**
+> **Status:** Source/reference system only. The former hosted demo is offline. Draft hardening [PR #11](https://github.com/claygeo/hyperliquid-trading-sim/pull/11) is CI-green but is not merged or deployed to production.
 
 ---
 


### PR DESCRIPTION
## What changed

- replaced the dead 	radeterm.app call to action with a truthful offline-demo status
- linked the separate CI-green hardening draft without implying it is merged or deployed to production

## Why

The default README sent visitors to a hosted demo that is no longer available. The production-facing documentation should be accurate even while the larger hardening PR remains intentionally unmerged.

## Impact

Documentation only. This does not change application code, database state, or any deployment. Draft PR #11 remains unmerged and must retain its production safety gate.

## Verification

- git diff --check
- branch changes only README.md
- stale 	radeterm.app / Trade Now wording is absent
- independent review verified PR #11 is draft and CI-green, and corrected the wording to distinguish its preview from production